### PR TITLE
fix(core-web): resolve all eslint no-unused-vars errors

### DIFF
--- a/core-web/eslint.config.js
+++ b/core-web/eslint.config.js
@@ -19,5 +19,13 @@ export default defineConfig([
       ecmaVersion: 2020,
       globals: globals.browser,
     },
+    rules: {
+      '@typescript-eslint/no-unused-vars': ['error', {
+        argsIgnorePattern: '^_',
+        varsIgnorePattern: '^_',
+        destructuredArrayIgnorePattern: '^_',
+        caughtErrorsIgnorePattern: '^_',
+      }],
+    },
   },
 ])

--- a/core-web/src/api/client.ts
+++ b/core-web/src/api/client.ts
@@ -1659,7 +1659,7 @@ export async function* regenerateMessage(
     }),
   });
 
-  let token = await ensureFreshToken();
+  const token = await ensureFreshToken();
   let response = await buildRequest(token);
 
   if (response.status === 401) {

--- a/core-web/src/components/Calendar/components/NewEventPopover.tsx
+++ b/core-web/src/components/Calendar/components/NewEventPopover.tsx
@@ -208,7 +208,7 @@ export default function NewEventPopover() {
       end_time = `${year}-${month}-${day}T23:59:59${tzOffset}`;
     } else {
       // Determine end time - use drag-to-create values if available, otherwise default to 1 hour
-      let finalEndHour = endHour !== undefined ? endHour : hour + 1;
+      const finalEndHour = endHour !== undefined ? endHour : hour + 1;
       const finalEndMinute = endMinute !== undefined ? endMinute : 0;
 
       // Handle multi-day events: if end time is past midnight, use next day

--- a/core-web/src/components/Calendar/utils/eventLayout.ts
+++ b/core-web/src/components/Calendar/utils/eventLayout.ts
@@ -282,7 +282,7 @@ export function calculateWeekEventPosition(
   dayColumnWidth: number,
   _dayIndex: number,
   hourHeight: number = 60,
-  _timeColumnWidth: number = 53,
+  _timeColumnWidth = 53,
   viewDate?: Date
 ): {
   top: number;

--- a/core-web/src/components/Files/NoteEditor.tsx
+++ b/core-web/src/components/Files/NoteEditor.tsx
@@ -496,7 +496,7 @@ function TableFloatingToolbar({ editor }: { editor: Editor }) {
 
     try {
       const tablePos = $from.before(depth);
-      let dom = editor.view.nodeDOM(tablePos);
+      const dom = editor.view.nodeDOM(tablePos);
       if (!(dom instanceof HTMLElement)) {
         setPosition(null);
         return;

--- a/core-web/src/components/Notifications/NotificationPanel.tsx
+++ b/core-web/src/components/Notifications/NotificationPanel.tsx
@@ -53,7 +53,6 @@ export default function NotificationPanel({ onNavigate }: NotificationPanelProps
 
   const handleInviteResolved = async (
     action: 'accept' | 'decline',
-    _notification: Notification,
   ) => {
     if (action === 'accept') {
       await useWorkspaceStore.getState().fetchInitData();

--- a/core-web/src/components/NotificationsPanel/NotificationsPanel.tsx
+++ b/core-web/src/components/NotificationsPanel/NotificationsPanel.tsx
@@ -57,7 +57,6 @@ export default function NotificationsPanel() {
 
   const handleInviteResolved = useCallback(async (
     action: 'accept' | 'decline',
-    _notification: Notification,
   ) => {
     if (action === 'accept') {
       await useWorkspaceStore.getState().fetchInitData();

--- a/core-web/src/components/Onboarding/steps/InviteStep.tsx
+++ b/core-web/src/components/Onboarding/steps/InviteStep.tsx
@@ -19,7 +19,6 @@ export default function InviteStep({
   onEmailsChange,
   onNext,
   onSkip,
-  onBack: _onBack,
 }: InviteStepProps) {
   const [inputValue, setInputValue] = useState("");
   const inputRef = useRef<HTMLInputElement>(null);

--- a/core-web/src/components/Onboarding/steps/ProfileStep.tsx
+++ b/core-web/src/components/Onboarding/steps/ProfileStep.tsx
@@ -22,7 +22,6 @@ export default function ProfileStep({
   onNameChange,
   onAvatarChange,
   onNext,
-  onBack: _onBack,
 }: ProfileStepProps) {
   const [uploading, setUploading] = useState(false);
   const [avatarPreview, setAvatarPreview] = useState<string | null>(null);

--- a/core-web/src/components/Onboarding/steps/WorkspaceNameStep.tsx
+++ b/core-web/src/components/Onboarding/steps/WorkspaceNameStep.tsx
@@ -14,7 +14,6 @@ export default function WorkspaceNameStep({
   value,
   onChange,
   onNext,
-  onBack: _onBack,
 }: WorkspaceNameStepProps) {
   const handleKeyDown = (e: React.KeyboardEvent) => {
     if (e.key === "Enter" && value.trim()) {

--- a/core-web/src/lib/notificationSound.ts
+++ b/core-web/src/lib/notificationSound.ts
@@ -11,7 +11,7 @@ function getAudioContext(): AudioContext | null {
   if (!audioContext) {
     try {
       audioContext = new (window.AudioContext || (window as any).webkitAudioContext)();
-    } catch (e) {
+    } catch {
       console.warn('Web Audio API not supported');
       return null;
     }

--- a/core-web/src/stores/calendarStore.ts
+++ b/core-web/src/stores/calendarStore.ts
@@ -201,7 +201,7 @@ function buildEventsByDateIndex(
   for (const event of events) {
     // Parse start and end dates - handle all-day events specially to avoid timezone shifts
     const isAllDay = event.all_day === true;
-    let currentDate = parseDateForIndexing(event.start_time, isAllDay);
+    const currentDate = parseDateForIndexing(event.start_time, isAllDay);
     const endDayOnly = parseDateForIndexing(event.end_time, isAllDay);
 
     // Add event to every date it spans
@@ -962,7 +962,7 @@ export const useCalendarStore = create<CalendarState>()(
         const endMinute = endTotalMinutes % 60;
 
         // Handle multi-day events: if end hour exceeds 23, move to next day
-        let endDate = new Date(newDate);
+        const endDate = new Date(newDate);
         if (endHour > 23) {
           endDate.setDate(endDate.getDate() + Math.floor(endHour / 24));
           endHour = endHour % 24;

--- a/core-web/src/stores/filesStore.ts
+++ b/core-web/src/stores/filesStore.ts
@@ -514,7 +514,7 @@ export const useFilesStore = create<FilesState>()(
 
         // Evict oldest cache entries to bound memory (keep max 3)
         const MAX_CACHED = 3;
-        let cache = { ...state.workspaceDocCache };
+        const cache = { ...state.workspaceDocCache };
         const entries = Object.entries(cache);
         if (entries.length >= MAX_CACHED && !cache[appId]) {
           const oldest = entries.sort(([, a], [, b]) => a.lastFetched - b.lastFetched)[0];

--- a/core-web/src/stores/messagesStore.ts
+++ b/core-web/src/stores/messagesStore.ts
@@ -43,7 +43,7 @@ function stripFileBlocks(messages: ChannelMessage[]): ChannelMessage[] {
     blocks: msg.blocks.map(block => {
       if (block.type === 'file') {
         // Keep file block structure and dimensions, but remove large URL data
-        const { url, preview, ...metadata } = block.data;
+        const { url: _url, preview: _preview, ...metadata } = block.data;
         return {
           ...block,
           data: {
@@ -1502,7 +1502,7 @@ export const useMessagesStore = create<MessagesState>()(
                   [activeChannelId]: messagesResult.messages,
                 },
               }));
-            } catch (msgErr) {
+            } catch {
               // Non-critical - messages will be fetched when user switches
               console.log(`[MessagesStore] Background message preload skipped for ${activeChannelId}`);
             }
@@ -1559,7 +1559,7 @@ export const useMessagesStore = create<MessagesState>()(
               try {
                 localStorage.setItem(name, JSON.stringify(value));
                 return;
-              } catch (retryError) {
+              } catch {
                 // Strategy 2: Try to save only the workspace cache (drop message cache)
                 try {
                   const minimalValue = {
@@ -1571,7 +1571,7 @@ export const useMessagesStore = create<MessagesState>()(
                   };
                   localStorage.setItem(name, JSON.stringify(minimalValue));
                   return;
-                } catch (minimalError) {
+                } catch {
                   // Strategy 3: Disable persistence and log once
                   if (!persistenceDisabled) {
                     persistenceDisabled = true;


### PR DESCRIPTION
## Summary
- Added underscore prefix ignore patterns (`^_`) to eslint config for args, vars, destructured arrays, and caught errors
- Removed unused destructured props (`_onBack` in Onboarding steps, `_notification` in Notification panels)
- Converted unused catch error params to bare `catch {}` blocks
- Applied `eslint --fix` for `prefer-const` and minor autofixes

Reduces eslint errors from 193 to 178 (15 no-unused-vars eliminated).

## Test plan
- [ ] Run `npm run lint` — no `no-unused-vars` errors should appear
- [ ] Run `npm run build` — no regressions
- [ ] Verify notification panels still handle invite accept/decline correctly