### PR TITLE
fix: tighten request model validation

### DIFF
--- a/core-api/api/request_types.py
+++ b/core-api/api/request_types.py
@@ -1,0 +1,39 @@
+"""Shared typed request values for API request models."""
+
+from enum import StrEnum
+
+
+class WorkspaceRole(StrEnum):
+    MEMBER = "member"
+    ADMIN = "admin"
+
+
+class WorkspaceAppType(StrEnum):
+    CHAT = "chat"
+    FILES = "files"
+    MESSAGES = "messages"
+    DASHBOARD = "dashboard"
+    PROJECTS = "projects"
+    EMAIL = "email"
+    CALENDAR = "calendar"
+    AGENTS = "agents"
+
+
+class ResourceType(StrEnum):
+    WORKSPACE_APP = "workspace_app"
+    FOLDER = "folder"
+    DOCUMENT = "document"
+    FILE = "file"
+    PROJECT_BOARD = "project_board"
+    CHANNEL = "channel"
+
+
+class PermissionLevel(StrEnum):
+    READ = "read"
+    WRITE = "write"
+    ADMIN = "admin"
+
+
+class AccessRequestStatus(StrEnum):
+    APPROVED = "approved"
+    DENIED = "denied"

--- a/core-api/api/routers/invitations.py
+++ b/core-api/api/routers/invitations.py
@@ -5,10 +5,11 @@ from __future__ import annotations
 from typing import List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, status
-from pydantic import BaseModel, EmailStr, Field
+from pydantic import BaseModel, EmailStr, Field, field_validator
 
 from api.dependencies import get_current_user_id, get_current_user_jwt
 from api.exceptions import handle_api_exception
+from api.request_types import WorkspaceRole
 from api.services.workspaces.invitations import (
     create_or_refresh_workspace_invitation,
     list_workspace_invitations,
@@ -27,7 +28,12 @@ router = APIRouter(prefix="/api/workspaces", tags=["workspace invitations"])
 
 class CreateInvitationRequest(BaseModel):
     email: EmailStr
-    role: str = Field(default="member", description="member|admin")
+    role: WorkspaceRole = Field(default=WorkspaceRole.MEMBER, description="member|admin")
+
+    @field_validator("role", mode="before")
+    @classmethod
+    def normalize_role(cls, value: WorkspaceRole | str) -> WorkspaceRole | str:
+        return value.strip().lower() if isinstance(value, str) else value
 
 
 class InvitationItemResponse(BaseModel):

--- a/core-api/api/routers/permissions.py
+++ b/core-api/api/routers/permissions.py
@@ -5,11 +5,12 @@ from typing import List, Dict, Any, Optional
 import logging
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response, status
-from pydantic import BaseModel, EmailStr, Field
+from pydantic import BaseModel, EmailStr, Field, field_validator
 
 from api.config import settings
 from api.dependencies import get_current_user_id, get_current_user_jwt
 from api.exceptions import handle_api_exception
+from api.request_types import AccessRequestStatus, PermissionLevel, ResourceType
 from api.rate_limit import limiter
 from api.services.permissions import (
     share_resource,
@@ -40,36 +41,68 @@ router = APIRouter(prefix="/api", tags=["permissions"])
 # ==========================================================================
 
 class ShareResourceRequest(BaseModel):
-    resource_type: str
+    resource_type: ResourceType
     resource_id: str
     grantee_email: EmailStr
-    permission: str = Field(default="read", description="read|write|admin")
+    permission: PermissionLevel = Field(default=PermissionLevel.READ, description="read|write|admin")
+
+    @field_validator("resource_type", "permission", mode="before")
+    @classmethod
+    def normalize_values(cls, value: ResourceType | PermissionLevel | str) -> ResourceType | PermissionLevel | str:
+        return value.strip().lower() if isinstance(value, str) else value
 
 
 class BatchShareGrant(BaseModel):
     email: EmailStr
-    permission: str = Field(default="read", description="read|write|admin")
+    permission: PermissionLevel = Field(default=PermissionLevel.READ, description="read|write|admin")
+
+    @field_validator("permission", mode="before")
+    @classmethod
+    def normalize_permission(cls, value: PermissionLevel | str) -> PermissionLevel | str:
+        return value.strip().lower() if isinstance(value, str) else value
 
 
 class BatchShareRequest(BaseModel):
-    resource_type: str
+    resource_type: ResourceType
     resource_id: str
     grants: List[BatchShareGrant]
 
+    @field_validator("resource_type", mode="before")
+    @classmethod
+    def normalize_resource_type(cls, value: ResourceType | str) -> ResourceType | str:
+        return value.strip().lower() if isinstance(value, str) else value
+
 
 class UpdateShareRequest(BaseModel):
-    permission: str
+    permission: PermissionLevel
+
+    @field_validator("permission", mode="before")
+    @classmethod
+    def normalize_permission(cls, value: PermissionLevel | str) -> PermissionLevel | str:
+        return value.strip().lower() if isinstance(value, str) else value
 
 
 class AccessRequestCreate(BaseModel):
-    resource_type: str
+    resource_type: ResourceType
     resource_id: str
     message: Optional[str] = None
 
+    @field_validator("resource_type", mode="before")
+    @classmethod
+    def normalize_resource_type(cls, value: ResourceType | str) -> ResourceType | str:
+        return value.strip().lower() if isinstance(value, str) else value
+
 
 class AccessRequestResolve(BaseModel):
-    status: str
-    permission: Optional[str] = "read"
+    status: AccessRequestStatus
+    permission: Optional[PermissionLevel] = PermissionLevel.READ
+
+    @field_validator("status", "permission", mode="before")
+    @classmethod
+    def normalize_values(cls, value: AccessRequestStatus | PermissionLevel | str | None) -> AccessRequestStatus | PermissionLevel | str | None:
+        if isinstance(value, str):
+            return value.strip().lower()
+        return value
 
 
 class PermissionItemResponse(BaseModel):
@@ -96,10 +129,15 @@ class ResourceSharesResponse(BaseModel):
 
 
 class CreateLinkRequest(BaseModel):
-    resource_type: str
+    resource_type: ResourceType
     resource_id: str
-    permission: str = Field(default="read", description="read|write|admin")
+    permission: PermissionLevel = Field(default=PermissionLevel.READ, description="read|write|admin")
     slug: Optional[str] = Field(default=None, description="Optional custom slug for the link")
+
+    @field_validator("resource_type", "permission", mode="before")
+    @classmethod
+    def normalize_values(cls, value: ResourceType | PermissionLevel | str) -> ResourceType | PermissionLevel | str:
+        return value.strip().lower() if isinstance(value, str) else value
 
 
 class UpdateLinkSlugRequest(BaseModel):

--- a/core-api/api/routers/workspaces.py
+++ b/core-api/api/routers/workspaces.py
@@ -2,8 +2,9 @@
 Workspaces router - HTTP endpoints for workspace management
 """
 from fastapi import APIRouter, HTTPException, status, Depends
-from pydantic import BaseModel, Field, EmailStr
+from pydantic import BaseModel, Field, EmailStr, field_validator
 from typing import Optional, Dict, Any, List
+from api.request_types import WorkspaceRole, WorkspaceAppType
 from api.services.workspaces import (
     get_workspaces,
     get_workspace_by_id,
@@ -63,7 +64,12 @@ class UpdateWorkspaceRequest(BaseModel):
 class AddMemberRequest(BaseModel):
     """Request model for adding a workspace member"""
     email: EmailStr = Field(..., description="Email of user to add")
-    role: str = Field(default="member", description="Role: 'member' or 'admin'")
+    role: WorkspaceRole = Field(default=WorkspaceRole.MEMBER, description="Role: 'member' or 'admin'")
+
+    @field_validator("role", mode="before")
+    @classmethod
+    def normalize_role(cls, value: WorkspaceRole | str) -> WorkspaceRole | str:
+        return value.strip().lower() if isinstance(value, str) else value
 
     class Config:
         json_schema_extra = {
@@ -76,14 +82,24 @@ class AddMemberRequest(BaseModel):
 
 class UpdateMemberRoleRequest(BaseModel):
     """Request model for updating a member's role"""
-    role: str = Field(..., description="New role: 'member' or 'admin'")
+    role: WorkspaceRole = Field(..., description="New role: 'member' or 'admin'")
+
+    @field_validator("role", mode="before")
+    @classmethod
+    def normalize_role(cls, value: WorkspaceRole | str) -> WorkspaceRole | str:
+        return value.strip().lower() if isinstance(value, str) else value
 
 
 class CreateAppRequest(BaseModel):
     """Request model for creating a workspace app"""
-    app_type: str = Field(..., description="App type (chat, files, messages, dashboard, projects, email, calendar, agents)")
+    app_type: WorkspaceAppType = Field(..., description="App type (chat, files, messages, dashboard, projects, email, calendar, agents)")
     is_public: bool = Field(default=True, description="Whether app is visible to all members")
     position: Optional[int] = Field(None, ge=0, description="Display order position")
+
+    @field_validator("app_type", mode="before")
+    @classmethod
+    def normalize_app_type(cls, value: WorkspaceAppType | str) -> WorkspaceAppType | str:
+        return value.strip().lower() if isinstance(value, str) else value
 
     class Config:
         json_schema_extra = {

--- a/core-api/tests/unit/test_request_model_validation.py
+++ b/core-api/tests/unit/test_request_model_validation.py
@@ -1,0 +1,71 @@
+from pydantic import ValidationError
+import pytest
+
+from api.routers.invitations import CreateInvitationRequest
+from api.routers.permissions import (
+    AccessRequestResolve,
+    CreateLinkRequest,
+    ShareResourceRequest,
+)
+from api.routers.workspaces import CreateAppRequest, UpdateMemberRoleRequest
+
+
+def test_workspace_role_fields_normalize_valid_input() -> None:
+    member = UpdateMemberRoleRequest(role=" ADMIN ")
+    invitation = CreateInvitationRequest(email="user@example.com", role=" member ")
+
+    assert member.role == "admin"
+    assert invitation.role == "member"
+
+
+def test_workspace_role_fields_reject_invalid_values() -> None:
+    with pytest.raises(ValidationError):
+        UpdateMemberRoleRequest(role="owner")
+
+    with pytest.raises(ValidationError):
+        CreateInvitationRequest(email="user@example.com", role="viewer")
+
+
+def test_create_app_request_normalizes_app_type() -> None:
+    request = CreateAppRequest(app_type=" Calendar ", is_public=True)
+
+    assert request.app_type == "calendar"
+
+
+def test_create_app_request_rejects_unknown_app_type() -> None:
+    with pytest.raises(ValidationError):
+        CreateAppRequest(app_type="tasks", is_public=True)
+
+
+def test_permission_requests_normalize_values() -> None:
+    share = ShareResourceRequest(
+        resource_type=" Document ",
+        resource_id="doc-1",
+        grantee_email="user@example.com",
+        permission=" WRITE ",
+    )
+    link = CreateLinkRequest(resource_type=" file ", resource_id="file-1", permission=" admin ")
+    resolve = AccessRequestResolve(status=" Approved ", permission=" read ")
+
+    assert share.resource_type == "document"
+    assert share.permission == "write"
+    assert link.resource_type == "file"
+    assert link.permission == "admin"
+    assert resolve.status == "approved"
+    assert resolve.permission == "read"
+
+
+def test_permission_requests_reject_invalid_values() -> None:
+    with pytest.raises(ValidationError):
+        ShareResourceRequest(
+            resource_type="workspace",
+            resource_id="doc-1",
+            grantee_email="user@example.com",
+            permission="read",
+        )
+
+    with pytest.raises(ValidationError):
+        CreateLinkRequest(resource_type="file", resource_id="file-1", permission="owner")
+
+    with pytest.raises(ValidationError):
+        AccessRequestResolve(status="pending", permission="read")


### PR DESCRIPTION

- move shared request-only values like roles, app types, resource types, permissions, and access request statuses into typed enums
- validate these at the router model layer so invalid values get rejected before reaching service code
- keep normal lowercase/trim handling for request bodies while improving the generated API schema
