### PR TITLE
feat(web): add error boundaries

### DIFF
--- a/core-web/src/App.tsx
+++ b/core-web/src/App.tsx
@@ -193,7 +193,9 @@ function AppLayout({ children }: { children: React.ReactNode }) {
           </main>
           {/* AI Chat Panel - right side */}
           <FeatureErrorBoundary feature="Chat">
-            <ChatPanel />
+            <Suspense fallback={null}>
+              <ChatPanel />
+            </Suspense>
           </FeatureErrorBoundary>
         </div>
       </div>

--- a/core-web/src/components/ui/FeatureErrorBoundary.tsx
+++ b/core-web/src/components/ui/FeatureErrorBoundary.tsx
@@ -51,7 +51,9 @@ export class FeatureErrorBoundary extends Component<Props, State> {
             Something went wrong in {this.props.feature}
           </p>
           <p className="text-xs text-text-secondary">
-            {this.state.error?.message || 'An unexpected error occurred.'}
+            {import.meta.env.DEV
+              ? (this.state.error?.message || 'An unexpected error occurred.')
+              : 'Something unexpected happened. Please try again.'}
           </p>
           <button
             onClick={this.handleReset}


### PR DESCRIPTION
Add FeatureErrorBoundary component that catches errors at the feature module level instead of crashing the entire app. A crash in one view now shows an inline "Try again" fallback while other features remain functional.

- Create FeatureErrorBoundary with Sentry error reporting and feature name attribution
- Wrap main content area in AppLayout to isolate route-level crashes
- Wrap ChatPanel independently so chat crashes don't affect other views
- Wrap AI Builder routes with their own boundary

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Feature-level error isolation added across the app (main view, chat panel, and AI Builder) to prevent one failing feature from affecting others.
  * User-friendly error fallback with a “Try again” option for graceful recovery.
  * Improved error capture and reporting for faster issue detection and diagnosis.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->