### PR TITLE
fix(supabase): remove stale todos migration refs, ignore cli temp state

### DIFF
--- a/core-api/.gitignore
+++ b/core-api/.gitignore
@@ -120,10 +120,7 @@ celerybeat.pid
 .DS_Store
 Thumbs.db
 .env*.local
-supabase/.temp/pooler-url
-supabase/.temp/postgres-version
-supabase/.temp/project-ref
-supabase/.temp/rest-version
+supabase/.temp/
 
 
 #claude

--- a/core-api/supabase/README.md
+++ b/core-api/supabase/README.md
@@ -11,7 +11,6 @@ supabase/
 │   ├── 00003_workspaces.sql              # workspaces, members, apps, app_members + RLS helpers
 │   ├── 00004_email_system.sql            # emails + thread RPCs + FTS
 │   ├── 00005_calendar_system.sql         # calendar_events
-│   ├── 00006_todos_system.sql            # todos, habit_completions + streak RPCs
 │   ├── 00007_files_and_documents.sql     # files, documents, note_attachments, document_versions
 │   ├── 00008_chat_system.sql             # conversations, messages, chat_attachments
 │   ├── 00009_sounds_system.sql           # sounds, playlists, user_listens

--- a/core-api/supabase/migrations/20260316000019_realtime_config.sql
+++ b/core-api/supabase/migrations/20260316000019_realtime_config.sql
@@ -30,20 +30,6 @@ BEGIN
 END $$;
 
 -- ============================================================================
--- todos
--- ============================================================================
-
-DO $$
-BEGIN
-  IF NOT EXISTS (
-    SELECT 1 FROM pg_publication_tables
-    WHERE pubname = 'supabase_realtime' AND tablename = 'todos'
-  ) THEN
-    ALTER PUBLICATION supabase_realtime ADD TABLE public.todos;
-  END IF;
-END $$;
-
--- ============================================================================
 -- documents
 -- ============================================================================
 


### PR DESCRIPTION
### Description

Couldn't setup the repo locally due to invalid references to the removed `todo` table. This PR fixes that by removing stale references to the `todo` table.

Also replaces individual `supabase/.temp/*` files with the entire folder in `.gitignore`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development infrastructure configurations and database migration documentation for improved project organization and clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->