### PR TITLE
chore: dependabot grouped updates, cooldowns & CI hardening

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,73 @@
+version: 2
+
+updates:
+  # ── Frontend (npm) ────────────────────────────────────────
+  - package-ecosystem: "npm"
+    directory: "/core-web"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    cooldown:
+      default-days: 7
+      semver-major-days: 14
+      semver-minor-days: 7
+      semver-patch-days: 3
+    groups:
+      npm-security:
+        applies-to: security-updates
+        patterns: ["*"]
+      npm-minor-patch:
+        applies-to: version-updates
+        update-types: ["minor", "patch"]
+      npm-major:
+        applies-to: version-updates
+        update-types: ["major"]
+    open-pull-requests-limit: 5
+    reviewers:
+      - "hackertron"
+    labels:
+      - "dependencies"
+      - "npm"
+
+  # ── Backend (pip) ─────────────────────────────────────────
+  - package-ecosystem: "pip"
+    directory: "/core-api"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    cooldown:
+      default-days: 7
+      semver-major-days: 14
+      semver-minor-days: 7
+      semver-patch-days: 3
+    groups:
+      pip-security:
+        applies-to: security-updates
+        patterns: ["*"]
+      pip-minor-patch:
+        applies-to: version-updates
+        update-types: ["minor", "patch"]
+      pip-major:
+        applies-to: version-updates
+        update-types: ["major"]
+    open-pull-requests-limit: 5
+    reviewers:
+      - "hackertron"
+    labels:
+      - "dependencies"
+      - "python"
+
+  # ── GitHub Actions ────────────────────────────────────────
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    groups:
+      actions-all:
+        applies-to: version-updates
+        patterns: ["*"]
+    open-pull-requests-limit: 3
+    labels:
+      - "dependencies"
+      - "ci"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,7 +172,7 @@ jobs:
           cache-dependency-path: core-web/package-lock.json
 
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --ignore-scripts
         env:
           HUGEICONS_TOKEN: ${{ secrets.HUGEICONS_TOKEN }}
 


### PR DESCRIPTION
## Summary
- Add `dependabot.yml` with grouped security and version updates per ecosystem (npm, pip, github-actions) — reduces 30+ individual PRs down to 2-3 grouped ones
- Add 7-14 day cooldown periods before suggesting new versions to mitigate supply chain attacks (blocks ~80% of historical attacks like the axios@1.14.1 RAT incident)
- Harden CI with `npm ci --ignore-scripts` to block malicious postinstall hooks

## What this changes
| File | Change |
|------|--------|
| `.github/dependabot.yml` | New config — grouped updates, cooldowns, labels, reviewers |
| `.github/workflows/ci.yml` | `npm ci` → `npm ci --ignore-scripts` |

## Repo settings already configured
- [x] Dependabot alerts enabled
- [x] Dependabot malware alerts enabled
- [x] Grouped security updates enabled
- [x] Dependabot security updates enabled
- [x] Auto-dismiss low-impact dev dependency alerts
- [x] Auto-dismiss false-positive malware alerts

## Test plan
- [ ] Verify Dependabot creates grouped PRs on next weekly run (Monday)
- [ ] Verify `npm ci --ignore-scripts` doesn't break the web build in CI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured automated dependency management with weekly update schedules for npm packages, Python dependencies, and GitHub Actions across project repositories. Set up grouped pull request strategy with assigned reviewers and ecosystem-specific labels for better dependency tracking.
  * Modified CI workflow dependency installation step to exclude package install scripts from execution during setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->