### PR TITLE
calendar: smooth drag-to-create, time line overlap, date picker fix

### DIFF
--- a/core-web/src/components/Calendar/components/CurrentTimeIndicator.tsx
+++ b/core-web/src/components/Calendar/components/CurrentTimeIndicator.tsx
@@ -30,7 +30,7 @@ export default function CurrentTimeIndicator({
 
   return (
     <div
-      className="absolute pointer-events-none z-20"
+      className="absolute pointer-events-none z-[110]"
       style={{
         top: topPosition,
         left: 0,

--- a/core-web/src/components/Calendar/components/NewEventBlock.tsx
+++ b/core-web/src/components/Calendar/components/NewEventBlock.tsx
@@ -1,6 +1,15 @@
 import { useEffect, useRef } from "react";
+import { motion } from "motion/react";
 import { formatTimeRangeCompact } from "../utils/dateHelpers";
 import { useCalendarStore } from "../../../stores/calendarStore";
+
+/** Spring aligned with 15-min vertical snap (hourHeight/4 px); tuned for quick follow without losing the smooth spring */
+const DRAG_CREATE_SPRING = {
+  type: "spring" as const,
+  stiffness: 780,
+  damping: 42,
+  mass: 0.55,
+};
 
 interface NewEventBlockProps {
   date: Date;
@@ -14,6 +23,8 @@ interface NewEventBlockProps {
   hourHeight?: number;
   timeColumnWidth?: number;
   title?: string;
+  /** True while pointer is down for drag-to-create — enables magnetic spring on size/position */
+  isDragging?: boolean;
 }
 
 export default function NewEventBlock({
@@ -28,6 +39,7 @@ export default function NewEventBlock({
   hourHeight = 60,
   timeColumnWidth = 53,
   title = "",
+  isDragging = false,
 }: NewEventBlockProps) {
   const blockRef = useRef<HTMLDivElement>(null);
   const updatePendingEventRect = useCalendarStore(
@@ -119,7 +131,13 @@ export default function NewEventBlock({
       const rect = blockRef.current.getBoundingClientRect();
       updatePendingEventRect(rect);
     }
-  }, [updatePendingEventRect]);
+  }, [
+    updatePendingEventRect,
+    position.top,
+    position.left,
+    position.width,
+    position.height,
+  ]);
 
   const getPadding = () => {
     if (isWeekView) return "6px 8px";
@@ -128,19 +146,24 @@ export default function NewEventBlock({
     return "10px 8px";
   };
 
-  const style = {
-    top: position.top,
-    left: position.left,
-    width: position.width,
-    height: position.height,
-    zIndex: 50,
-  };
-
   return (
-    <div
+    <motion.div
       ref={blockRef}
+      initial={false}
+      animate={{
+        top: position.top,
+        left: position.left,
+        width: position.width,
+        height: position.height,
+      }}
+      transition={isDragging ? DRAG_CREATE_SPRING : { duration: 0 }}
+      onAnimationComplete={() => {
+        if (blockRef.current) {
+          updatePendingEventRect(blockRef.current.getBoundingClientRect());
+        }
+      }}
       className="absolute pointer-events-auto text-left bg-[#D6EFF8] rounded-md ring-2 ring-[#35A9DD] overflow-hidden"
-      style={style}
+      style={{ zIndex: 50 }}
     >
       <div
         className={`h-full flex ${isVeryShortEvent ? 'items-center gap-1.5' : 'gap-2.5'}`}
@@ -180,6 +203,6 @@ export default function NewEventBlock({
           )}
         </div>
       </div>
-    </div>
+    </motion.div>
   );
 }

--- a/core-web/src/components/Calendar/components/NewEventPopover.tsx
+++ b/core-web/src/components/Calendar/components/NewEventPopover.tsx
@@ -308,7 +308,15 @@ export default function NewEventPopover() {
     if (!isOpen) return;
 
     const handleClickOutside = (e: MouseEvent) => {
-      if (popoverRef.current && !popoverRef.current.contains(e.target as Node)) {
+      const target = e.target as Node;
+      // DatePicker dropdown is portaled to document.body — not inside popoverRef
+      if (
+        target instanceof Element &&
+        target.closest("[data-datepicker-portal]")
+      ) {
+        return;
+      }
+      if (popoverRef.current && !popoverRef.current.contains(target)) {
         // Get fresh state from store
         const currentPending = useCalendarStore.getState().pendingEvent;
         if (currentPending?.title.trim()) {

--- a/core-web/src/components/Calendar/components/TimelineGrid.tsx
+++ b/core-web/src/components/Calendar/components/TimelineGrid.tsx
@@ -45,6 +45,7 @@ export default function TimelineGrid({
   const startDraggingToCreate = useCalendarStore((state) => state.startDraggingToCreate);
   const updateDragToCreate = useCalendarStore((state) => state.updateDragToCreate);
   const cancelCreatingEvent = useCalendarStore((state) => state.cancelCreatingEvent);
+  const finishDragToCreate = useCalendarStore((state) => state.finishDragToCreate);
 
   const timedEvents = useMemo(
     () => getTimedEventsForDate(date),
@@ -135,20 +136,16 @@ export default function TimelineGrid({
       document.removeEventListener('pointermove', handlePointerMove);
       document.removeEventListener('pointerup', handlePointerUp);
 
-      // Only show popover if drag was sufficient
-      const state = useCalendarStore.getState();
-      if (!hasMovedEnough && state.pendingEvent?.isDragging) {
-        // Drag-to-create was successful, popover should appear
-        // User must enter a title to create the event
-      } else if (!hasMovedEnough) {
-        // Drag was too short, cancel any pending drag-to-create
+      if (hasMovedEnough) {
+        finishDragToCreate();
+      } else {
         cancelCreatingEvent();
       }
     };
 
     document.addEventListener('pointermove', handlePointerMove);
     document.addEventListener('pointerup', handlePointerUp);
-  }, [date, calculateTimeFromPosition, updateDragToCreate, startDraggingToCreate, cancelCreatingEvent, pendingEvent?.isDragging]);
+  }, [date, calculateTimeFromPosition, updateDragToCreate, startDraggingToCreate, cancelCreatingEvent, finishDragToCreate, pendingEvent?.isDragging]);
 
   return (
     <div className="flex-1 flex flex-col overflow-hidden">
@@ -266,6 +263,7 @@ export default function TimelineGrid({
               hourHeight={hourHeight}
               timeColumnWidth={timeColumnWidth}
               title={pendingEvent.title}
+              isDragging={pendingEvent.isDragging === true}
             />
           )}
         </div>

--- a/core-web/src/components/Calendar/components/WeekView.tsx
+++ b/core-web/src/components/Calendar/components/WeekView.tsx
@@ -73,6 +73,9 @@ export default function WeekView({
   const cancelCreatingEvent = useCalendarStore(
     (state) => state.cancelCreatingEvent,
   );
+  const finishDragToCreate = useCalendarStore(
+    (state) => state.finishDragToCreate,
+  );
 
   const weekStart = useMemo(() => startOfWeek(selectedDate), [selectedDate]);
   const weekDays = useMemo(() => getWeekDays(weekStart), [weekStart]);
@@ -193,13 +196,9 @@ export default function WeekView({
         document.removeEventListener("pointermove", handlePointerMove);
         document.removeEventListener("pointerup", handlePointerUp);
 
-        // Only show popover if drag was sufficient
-        const state = useCalendarStore.getState();
-        if (!hasMovedEnough && state.pendingEvent?.isDragging) {
-          // Drag-to-create was successful, popover should appear
-          // User must enter a title to create the event
-        } else if (!hasMovedEnough) {
-          // Drag was too short, cancel any pending drag-to-create
+        if (hasMovedEnough) {
+          finishDragToCreate();
+        } else {
           cancelCreatingEvent();
         }
       };
@@ -213,6 +212,7 @@ export default function WeekView({
       updateDragToCreate,
       startDraggingToCreate,
       cancelCreatingEvent,
+      finishDragToCreate,
       pendingEvent?.isDragging,
     ],
   );
@@ -473,6 +473,7 @@ export default function WeekView({
                       hourHeight={HOUR_HEIGHT}
                       timeColumnWidth={TIME_COLUMN_WIDTH}
                       title={pendingEvent.title}
+                      isDragging={pendingEvent.isDragging === true}
                     />
                   )}
                 </div>
@@ -505,7 +506,7 @@ function CurrentTimeIndicatorWeek({
 
   return (
     <div
-      className="absolute pointer-events-none z-20"
+      className="absolute pointer-events-none z-[110]"
       style={{
         top: topPosition,
         left: -circleSize / 2,

--- a/core-web/src/components/ui/DatePicker.tsx
+++ b/core-web/src/components/ui/DatePicker.tsx
@@ -317,6 +317,7 @@ export default function DatePicker({
       {isOpen && createPortal(
         <div
           ref={dropdownRef}
+          data-datepicker-portal
           onClick={(e) => e.stopPropagation()}
           className={`fixed z-10000 bg-white rounded-lg shadow-lg border border-gray-200 overflow-hidden ${dropdownClassName}`}
           style={{

--- a/core-web/src/stores/calendarStore.ts
+++ b/core-web/src/stores/calendarStore.ts
@@ -117,6 +117,8 @@ interface CalendarState {
     triggerRect: DOMRect,
   ) => void;
   updateDragToCreate: (endHour: number, endMinute: number) => void;
+  /** Call when pointer-up ends drag-to-create so UI can stop spring-animating the preview */
+  finishDragToCreate: () => void;
 
   // Event actions
   addEvent: (event: CalendarEvent) => void;
@@ -766,6 +768,13 @@ export const useCalendarStore = create<CalendarState>()(
               endMinute,
             },
           });
+        }
+      },
+
+      finishDragToCreate: () => {
+        const pending = get().pendingEvent;
+        if (pending?.isDragging) {
+          set({ pendingEvent: { ...pending, isDragging: false } });
         }
       },
 


### PR DESCRIPTION
- drag-to-create: the preview glides to each time slot instead of jumping; releasing the mouse lets the add-event panel open cleanly.
- “now” line: the orange line stays on top of events so you can always see the current time.
- mini calendar: next/previous month no longer closes the add-event form by mistake.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * DatePicker interactions no longer close the event-creation popover unexpectedly.

* **Improvements**
  * Smoother, animated drag-to-create behavior with more reliable completion when releasing a drag.
  * Updated visual layering of calendar elements to improve clarity during interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->