### PR TITLE
feat: add optional email/password auth for self-hosted deployments

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,10 @@ cp core-api/.env.example core-api/.env
 cp core-web/.env.example core-web/.env
 
 # Edit both .env files with your Supabase credentials
+
+# Optional: enable email/password sign-in (skips OAuth setup)
+# In core-web/.env, set:
+#   VITE_ENABLE_EMAIL_AUTH=true
 ```
 
 ### 2. Set up the database

--- a/core-web/.env.example
+++ b/core-web/.env.example
@@ -18,6 +18,16 @@ VITE_SUPABASE_URL=https://your-project.supabase.co
 VITE_SUPABASE_ANON_KEY=your-anon-key
 
 # ------------------------------------------------------------------------------
+# [OPTIONAL] Email/Password Auth — Self-hosted
+# ------------------------------------------------------------------------------
+# Enables email/password sign-in on the landing page.
+# Disabled by default (hosted app uses OAuth only).
+# Set to "true" for self-hosted deployments without OAuth configured.
+# Tip: disable "Enable email confirmations" in Supabase (Auth > Settings)
+# to skip the verification email step during local development.
+VITE_ENABLE_EMAIL_AUTH=
+
+# ------------------------------------------------------------------------------
 # [OPTIONAL] Sentry — Error Tracking
 # ------------------------------------------------------------------------------
 # Disabled if empty (no errors sent, app works normally)

--- a/core-web/src/components/Landing/LandingPage.tsx
+++ b/core-web/src/components/Landing/LandingPage.tsx
@@ -6,6 +6,7 @@ import { useAuthStore } from "../../stores/authStore";
 import { API_BASE } from "../../lib/apiBase";
 
 const TURNSTILE_SITE_KEY = import.meta.env.VITE_TURNSTILE_SITE_KEY || "";
+const ENABLE_EMAIL_AUTH = import.meta.env.VITE_ENABLE_EMAIL_AUTH === "true";
 
 /* ──────────────────── Styles ──────────────────── */
 
@@ -51,15 +52,28 @@ function MicrosoftIcon() {
 /* ──────────────────── Sign-in modal ──────────────────── */
 
 function SignInModal({ isOpen, onClose }: { isOpen: boolean; onClose: () => void }) {
-  const { signInWithGoogle, signInWithMicrosoft } = useAuthStore();
+  const { signInWithGoogle, signInWithMicrosoft, signInWithEmail, signUpWithEmail } = useAuthStore();
   const [turnstileToken, setTurnstileToken] = useState<string | null>(null);
   const [verifying, setVerifying] = useState(false);
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [emailError, setEmailError] = useState("");
+  const [emailLoading, setEmailLoading] = useState(false);
+  const [isSignUp, setIsSignUp] = useState(false);
+  const showEmailAuth = ENABLE_EMAIL_AUTH;
 
   const hasTurnstile = !!TURNSTILE_SITE_KEY;
 
-  // Reset token when modal closes
+  // Reset state when modal closes
   useEffect(() => {
-    if (!isOpen) setTurnstileToken(null);
+    if (!isOpen) {
+      setTurnstileToken(null);
+      setEmail("");
+      setPassword("");
+      setEmailError("");
+      setEmailLoading(false);
+      setIsSignUp(false);
+    }
   }, [isOpen]);
 
   useEffect(() => {
@@ -98,6 +112,7 @@ function SignInModal({ isOpen, onClose }: { isOpen: boolean; onClose: () => void
   }, [hasTurnstile, turnstileToken, signInWithGoogle, signInWithMicrosoft]);
 
   const buttonsDisabled = hasTurnstile && (!turnstileToken || verifying);
+  const emailSubmitLabel = isSignUp ? "Sign up with Email" : "Sign in with Email";
 
   return createPortal(
     <AnimatePresence>
@@ -144,6 +159,66 @@ function SignInModal({ isOpen, onClose }: { isOpen: boolean; onClose: () => void
                 <MicrosoftIcon />
                 Continue with Microsoft
               </button>
+              {showEmailAuth && (
+                <>
+                  <div className="relative my-2">
+                    <div className="absolute inset-0 flex items-center"><div className="w-full border-t border-black/10" /></div>
+                    <div className="relative flex justify-center text-xs"><span className="bg-white px-2 text-text-tertiary">or</span></div>
+                  </div>
+                  <form
+                    onSubmit={async (e) => {
+                      e.preventDefault();
+                      setEmailError("");
+                      setEmailLoading(true);
+                      try {
+                        if (isSignUp) {
+                          await signUpWithEmail(email, password);
+                        } else {
+                          await signInWithEmail(email, password);
+                        }
+                      } catch (err: unknown) {
+                        setEmailError(err instanceof Error ? err.message : "Auth failed");
+                      } finally {
+                        setEmailLoading(false);
+                      }
+                    }}
+                    className="space-y-2"
+                  >
+                    <input
+                      type="email"
+                      placeholder="Email"
+                      value={email}
+                      onChange={(e) => setEmail(e.target.value)}
+                      required
+                      className="w-full px-4 py-3 border border-black/20 rounded-xl text-base focus:outline-none focus:ring-2 focus:ring-black/20"
+                    />
+                    <input
+                      type="password"
+                      placeholder="Password"
+                      value={password}
+                      onChange={(e) => setPassword(e.target.value)}
+                      required
+                      minLength={6}
+                      className="w-full px-4 py-3 border border-black/20 rounded-xl text-base focus:outline-none focus:ring-2 focus:ring-black/20"
+                    />
+                    {emailError && <p className="text-red-500 text-xs">{emailError}</p>}
+                    <button
+                      type="submit"
+                      disabled={emailLoading}
+                      className="w-full px-4 py-3 bg-text-body text-white rounded-xl text-base font-medium hover:bg-black/80 transition-all disabled:opacity-40"
+                    >
+                      {emailLoading ? "..." : emailSubmitLabel}
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => { setIsSignUp(!isSignUp); setEmailError(""); }}
+                      className="w-full text-xs text-text-tertiary hover:text-text-body transition-colors"
+                    >
+                      {isSignUp ? "Already have an account? Sign in" : "No account? Sign up"}
+                    </button>
+                  </form>
+                </>
+              )}
             </div>
             {hasTurnstile && (
               <div className="mt-4 flex justify-center">


### PR DESCRIPTION
## Summary

Self-hosted users currently have no way to sign in without first configuring Google or Microsoft OAuth credentials. Setting up OAuth for a local or self-hosted instance means creating a cloud project, registering redirect URIs, and managing client secrets — overhead that isn't worth it when you just want to run Core on your own infrastructure.

This PR adds an optional email/password sign-in form to the landing page, gated behind a single env var. The hosted app is completely unaffected — the form only appears when explicitly enabled.

### Before (default — unchanged)
Only OAuth buttons shown. No configuration needed for hosted deployments.

### After (`VITE_ENABLE_EMAIL_AUTH=true`)
<img width="1195" height="1261" alt="image" src="https://github.com/user-attachments/assets/45671460-db20-4932-896f-8cbc5b2f9156" />

Email/password form appears below OAuth, using Supabase's built-in email auth. No additional backend changes required.

## Changes
- `core-web/src/components/Landing/LandingPage.tsx` — email/password form with sign-in/sign-up toggle, conditionally rendered when `VITE_ENABLE_EMAIL_AUTH=true`
- `core-web/.env.example` — documented new env var under `[OPTIONAL]` tier with usage guidance

## Usage

```bash
# In core-web/.env
VITE_ENABLE_EMAIL_AUTH=true
```

> **Tip:** For local development, disable "Enable email confirmations" in your Supabase project (Auth → Settings) to skip the verification email step. The default confirmation flow sends a link to `localhost`, which won't work if you open it from a different device.

## Follow-up
- `InviteAcceptPage` and `ShareLinkResolver` also have sign-in flows but only offer OAuth. Self-hosted users who receive an invite or share link would still be blocked without OAuth configured. Email auth should be extended to those surfaces in a follow-up PR.

## Test plan
- [ ] Default (no env var): only OAuth buttons shown, no email form
- [ ] `VITE_ENABLE_EMAIL_AUTH=true`: email form appears below OAuth buttons with "or" divider
- [ ] Sign up with email/password → account created, redirect to onboarding
- [ ] Sign in with existing email/password → redirect to app
- [ ] Error states display correctly (wrong password, invalid email)
- [ ] Close and reopen modal → form state is reset (no stale password/errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)