### PR TITLE
feat: add Docker Compose for single-command local development

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,28 @@ npm run dev
 # App runs at http://localhost:5173
 ```
 
+### Alternative: Docker Compose
+
+Skip steps 3–4 and run both services with a single command. Requires [Docker](https://docs.docker.com/get-docker/).
+
+```bash
+# 1. Set up env files and database (steps 1–2 above), then:
+docker compose up
+
+# API at http://localhost:8000
+# Frontend at http://localhost:3000
+```
+
+Both services run in development mode with **hot reload** — edit files locally and changes appear immediately without restarting containers.
+
+To customize ports, set `CORE_API_PORT` or `CORE_WEB_PORT` in your shell:
+
+```bash
+CORE_API_PORT=9000 CORE_WEB_PORT=4000 docker compose up
+```
+
+> **Note:** Database migrations still require the [Supabase CLI](https://supabase.com/docs/guides/cli) on your host machine (step 2). The Docker setup handles only the API and frontend.
+
 ## Architecture
 
 ```

--- a/core-api/.dockerignore
+++ b/core-api/.dockerignore
@@ -1,0 +1,5 @@
+.venv
+__pycache__
+.pytest_cache
+.env
+.git

--- a/core-api/Dockerfile
+++ b/core-api/Dockerfile
@@ -1,0 +1,14 @@
+FROM python:3.13-slim
+
+WORKDIR /app
+
+# Install dependencies
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy application code
+COPY . .
+
+EXPOSE 8000
+
+CMD ["python", "dev.py"]

--- a/core-web/.dockerignore
+++ b/core-web/.dockerignore
@@ -1,0 +1,4 @@
+node_modules
+dist
+.env
+.git

--- a/core-web/Dockerfile
+++ b/core-web/Dockerfile
@@ -1,0 +1,14 @@
+FROM node:22-slim
+
+WORKDIR /app
+
+# Install dependencies
+COPY package.json package-lock.json ./
+RUN npm ci
+
+# Copy application code
+COPY . .
+
+EXPOSE 3000
+
+CMD ["npm", "run", "dev", "--", "--host"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,31 @@
+services:
+  api:
+    build: ./core-api
+    ports:
+      - "${CORE_API_PORT:-8000}:8000"
+    env_file:
+      - ./core-api/.env
+    volumes:
+      - ./core-api:/app
+      - /app/__pycache__
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/')"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+      start_period: 15s
+    restart: unless-stopped
+
+  web:
+    build: ./core-web
+    ports:
+      - "${CORE_WEB_PORT:-3000}:3000"
+    env_file:
+      - ./core-web/.env
+    volumes:
+      - ./core-web:/app
+      - /app/node_modules
+    depends_on:
+      api:
+        condition: service_healthy
+    restart: unless-stopped


### PR DESCRIPTION
## Summary

Contributors and self-hosters currently need to install Node.js, Python, uv, and manage two separate terminal processes to run Core locally. This PR adds Docker Compose so the entire stack comes up with a single command — no language runtimes required on the host.

```bash
docker compose up
# API at http://localhost:8000, frontend at http://localhost:3000
```

## Changes
- `docker-compose.yml` — two-service dev setup with health checks, volume mounts, and configurable ports
- `core-api/Dockerfile` — Python 3.13 slim image running uvicorn with hot reload
- `core-web/Dockerfile` — Node 22 slim image running Vite dev server with hot reload
- `core-api/.dockerignore` / `core-web/.dockerignore` — keeps images lean
- `README.md` — Docker Compose section added to Quick Start

## Details

- **Hot reload** — source directories are volume-mounted, so edits on the host are reflected immediately without rebuilding
- **Health checks** — the web container waits for the API to be healthy before starting
- **Port customization** — `CORE_API_PORT=9000 CORE_WEB_PORT=4000 docker compose up`
- **Development only** — this runs dev servers (uvicorn with reload, Vite dev), not a production build

> **Note:** Database migrations still require the Supabase CLI on the host machine. Docker handles only the API and frontend services.

## Test plan
- [ ] `docker compose up` starts both services, API healthy before web starts
- [ ] Frontend loads at http://localhost:3000
- [ ] API responds at http://localhost:8000
- [ ] Edit a Python file → API auto-reloads
- [ ] Edit a React component → Vite hot-reloads in browser
- [ ] Custom ports work: `CORE_API_PORT=9000 docker compose up`
- [ ] `docker compose down` cleans up cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)