### PR TITLE
feat: add Docker Compose for single-command local development

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,82 @@
+# ==============================================================================
+# Core — Docker Compose Environment Variables
+# ==============================================================================
+# Copy this file to .env and fill in the values.
+# Used by `docker compose up` to configure both the API and frontend.
+#
+# For non-Docker setups, use core-api/.env and core-web/.env instead.
+# ==============================================================================
+
+# ------------------------------------------------------------------------------
+# [REQUIRED] Supabase
+# ------------------------------------------------------------------------------
+# Create a project at https://supabase.com and grab these from Settings > API
+SUPABASE_URL=https://your-project.supabase.co
+SUPABASE_ANON_KEY=your-anon-key
+SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
+SUPABASE_JWT_SECRET=your-jwt-secret
+
+# Frontend Supabase config (must match the values above)
+VITE_SUPABASE_URL=https://your-project.supabase.co
+VITE_SUPABASE_ANON_KEY=your-anon-key
+
+# ------------------------------------------------------------------------------
+# [REQUIRED] API
+# ------------------------------------------------------------------------------
+API_ENV=development
+DEBUG=false
+# If you override CORE_WEB_PORT, update this to match (e.g. http://localhost:4000)
+FRONTEND_URL=http://localhost:3000
+# If you override CORE_API_PORT, update this to match (e.g. http://localhost:9000/api)
+VITE_API_URL=http://localhost:8000/api
+# Comma-separated CORS origins. Only needed if running on non-default ports.
+# ALLOWED_ORIGINS_ENV=http://localhost:4000
+
+# ------------------------------------------------------------------------------
+# [OPTIONAL] Email/Password Auth — Self-hosted
+# ------------------------------------------------------------------------------
+# Set to "true" to enable email/password sign-in (skips OAuth setup).
+# Tip: disable "Enable email confirmations" in Supabase (Auth > Settings)
+# to skip the verification email step during local development.
+# VITE_ENABLE_EMAIL_AUTH=true
+
+# ------------------------------------------------------------------------------
+# [OPTIONAL] Sentry — Error Tracking
+# ------------------------------------------------------------------------------
+# SENTRY_DSN=
+# VITE_SENTRY_DSN=
+
+# ------------------------------------------------------------------------------
+# [OPTIONAL] PostHog — Analytics
+# ------------------------------------------------------------------------------
+# VITE_POSTHOG_KEY=
+# VITE_POSTHOG_HOST=
+
+# ------------------------------------------------------------------------------
+# [FEATURE] AI Chat — OpenAI / Anthropic
+# ------------------------------------------------------------------------------
+# OPENAI_API_KEY=sk-...
+# ANTHROPIC_API_KEY=sk-ant-...
+
+# ------------------------------------------------------------------------------
+# [FEATURE] File Storage — Cloudflare R2
+# ------------------------------------------------------------------------------
+# R2_ACCOUNT_ID=your-account-id
+# R2_ACCESS_KEY_ID=your-access-key
+# R2_SECRET_ACCESS_KEY=your-secret-key
+# R2_BUCKET_NAME=core-os-files
+# R2_S3_API=https://your-account-id.r2.cloudflarestorage.com
+# R2_PUBLIC_URL=https://files.yourdomain.com
+
+# ------------------------------------------------------------------------------
+# [FEATURE] Google OAuth — Gmail & Calendar Sync
+# ------------------------------------------------------------------------------
+# GOOGLE_CLIENT_ID=your-client-id.apps.googleusercontent.com
+# GOOGLE_CLIENT_SECRET=your-client-secret
+
+# ------------------------------------------------------------------------------
+# [FEATURE] Microsoft OAuth — Outlook & Microsoft 365 Sync
+# ------------------------------------------------------------------------------
+# MICROSOFT_CLIENT_ID=your-client-id
+# MICROSOFT_CLIENT_SECRET=your-client-secret
+# MICROSOFT_TENANT_ID=common

--- a/README.md
+++ b/README.md
@@ -81,6 +81,36 @@ npm run dev
 # App runs at http://localhost:5173
 ```
 
+### Alternative: Docker Compose
+
+Run both services with a single command. Requires [Docker](https://docs.docker.com/get-docker/).
+
+```bash
+# 1. Configure environment (single file for both services)
+cp .env.example .env
+# Edit .env with your Supabase credentials
+
+# 2. Set up the database (requires Supabase CLI on host)
+cd core-api
+supabase link --project-ref YOUR_PROJECT_REF
+supabase db push
+cd ..
+
+# 3. Start everything
+docker compose up
+
+# API at http://localhost:8000
+# Frontend at http://localhost:3000
+```
+
+Both services run in development mode with **hot reload** — edit files locally and changes appear immediately without restarting containers.
+
+To customize ports:
+
+```bash
+CORE_API_PORT=9000 CORE_WEB_PORT=4000 docker compose up
+```
+
 ## Architecture
 
 ```

--- a/core-api/.dockerignore
+++ b/core-api/.dockerignore
@@ -1,0 +1,5 @@
+.venv
+__pycache__
+.pytest_cache
+.env
+.git

--- a/core-api/Dockerfile
+++ b/core-api/Dockerfile
@@ -1,0 +1,23 @@
+FROM python:3.13-slim
+
+RUN useradd --create-home appuser
+
+WORKDIR /app
+
+# Install dependencies
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy only the application code needed to run
+COPY api/ api/
+COPY lib/ lib/
+COPY index.py dev.py ./
+
+RUN chown -R appuser:appuser /app
+
+USER appuser
+
+EXPOSE 8000
+
+# Development server with hot reload
+CMD ["python", "dev.py"]

--- a/core-web/.dockerignore
+++ b/core-web/.dockerignore
@@ -1,0 +1,4 @@
+node_modules
+dist
+.env
+.git

--- a/core-web/Dockerfile
+++ b/core-web/Dockerfile
@@ -1,0 +1,21 @@
+FROM node:22-slim
+
+WORKDIR /app
+
+# Install dependencies
+COPY package.json package-lock.json ./
+RUN npm ci
+
+# Copy only the application code needed to run
+COPY index.html vite.config.ts tsconfig.json tsconfig.app.json tsconfig.node.json ./
+COPY src/ src/
+COPY public/ public/
+
+RUN chown -R node:node /app
+
+USER node
+
+EXPOSE 3000
+
+# Development server with hot reload
+CMD ["npm", "run", "dev", "--", "--host"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,33 @@
+services:
+  api:
+    build: ./core-api
+    user: "${UID:-1000}:${GID:-1000}"
+    ports:
+      - "${CORE_API_PORT:-8000}:8000"
+    env_file:
+      - .env
+    volumes:
+      - ./core-api:/app
+      - /app/__pycache__
+    healthcheck:
+      test: ["CMD", "python", "-c", "import httpx; httpx.get('http://localhost:8000/')"]
+      interval: 10s
+      timeout: 15s
+      retries: 5
+      start_period: 30s
+    restart: unless-stopped
+
+  web:
+    build: ./core-web
+    user: "${UID:-1000}:${GID:-1000}"
+    ports:
+      - "${CORE_WEB_PORT:-3000}:3000"
+    env_file:
+      - .env
+    volumes:
+      - ./core-web:/app
+      - /app/node_modules
+    depends_on:
+      api:
+        condition: service_healthy
+    restart: unless-stopped


### PR DESCRIPTION
## Summary

Getting Core running locally currently requires installing Node.js, Python, uv, and managing two separate processes. This PR adds Docker Compose so the entire stack comes up with a single command and a single env file — no language runtimes needed on the host.

```bash
cp .env.example .env    # one file for both services
# fill in Supabase credentials, then:
docker compose up
```

## Changes
- `.env.example` — single env file for both API and frontend (replaces the need to configure two separate files)
- `docker-compose.yml` — two-service dev setup with health checks, volume mounts, and configurable ports
- `core-api/Dockerfile` — Python 3.13 slim image running uvicorn with hot reload
- `core-web/Dockerfile` — Node 22 slim image running Vite dev server with hot reload
- `core-api/.dockerignore` / `core-web/.dockerignore` — keeps images lean
- `README.md` — Docker Compose section added to Quick Start

## Details

- **Single `.env`** — one file at the repo root configures both services. The per-service env files (`core-api/.env`, `core-web/.env`) still work for non-Docker setups
- **Hot reload** — source directories are volume-mounted, so edits on the host are reflected immediately without rebuilding
- **Health checks** — the web container waits for the API to report healthy before starting
- **Port customization** — `CORE_API_PORT=9000 CORE_WEB_PORT=4000 docker compose up`
- **Development only** — this runs dev servers (uvicorn with reload, Vite dev), not a production build
- **No image proxy** — `core-image-proxy` is a Cloudflare Worker and not needed for local dev (the API falls back to presigned R2 URLs)

> **Note:** Database migrations still require the Supabase CLI on the host (`supabase db push`). Docker handles only the API and frontend services.

## Test plan
- [ ] `docker compose up` starts both services, API healthy before web starts
- [ ] Frontend loads at http://localhost:3000
- [ ] API responds at http://localhost:8000
- [ ] Edit a Python file → API auto-reloads
- [ ] Edit a React component → Vite hot-reloads in browser
- [ ] Custom ports work: `CORE_API_PORT=9000 docker compose up`
- [ ] `docker compose down` cleans up cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a Docker Compose quick-start describing how to run API and frontend together locally, expected URLs, hot-reload behavior, and port override examples.

* **Chores**
  * Added a containerized dev setup for API and frontend with health checks, Docker build/context exclusions, and a root .env template documenting required runtime/Supabase variables plus optional integrations and AI key placeholders.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->