### PR TITLE
Add loading state to Create Project and Create Channel modals

### DIFF
--- a/core-web/src/components/Messages/MessagesView.tsx
+++ b/core-web/src/components/Messages/MessagesView.tsx
@@ -1174,6 +1174,7 @@ export default function MessagesView() {
   const [newChannelName, setNewChannelName] = useState("");
   const [newChannelDescription, setNewChannelDescription] = useState("");
   const [newChannelPrivate, setNewChannelPrivate] = useState(false);
+  const [isCreatingChannel, setIsCreatingChannel] = useState(false);
   const [editingMessageId, setEditingMessageId] = useState<string | null>(null);
   const [editingContent, setEditingContent] = useState("");
   const [workspaceMembers, setWorkspaceMembers] = useState<
@@ -1977,8 +1978,9 @@ export default function MessagesView() {
 
   const handleCreateChannel = async (e: React.FormEvent) => {
     e.preventDefault();
-    if (!newChannelName.trim()) return;
+    if (!newChannelName.trim() || isCreatingChannel) return;
 
+    setIsCreatingChannel(true);
     try {
       const channel = await addChannel(
         newChannelName,
@@ -1992,6 +1994,8 @@ export default function MessagesView() {
       navigateToChannel(channel.id);
     } catch (err) {
       console.error("Failed to create channel:", err);
+    } finally {
+      setIsCreatingChannel(false);
     }
   };
 
@@ -3152,10 +3156,10 @@ export default function MessagesView() {
                   </button>
                   <button
                     type="submit"
-                    disabled={!newChannelName.trim()}
+                    disabled={!newChannelName.trim() || isCreatingChannel}
                     className="px-3 py-2 text-[12px] font-medium bg-gray-900 text-white rounded-lg hover:bg-gray-800 disabled:opacity-40 disabled:cursor-not-allowed transition-all"
                   >
-                    Create
+                    {isCreatingChannel ? 'Creating...' : 'Create'}
                   </button>
                 </div>
               </form>

--- a/core-web/src/components/Projects/components/CreateProjectModal.tsx
+++ b/core-web/src/components/Projects/components/CreateProjectModal.tsx
@@ -84,10 +84,10 @@ export default function CreateProjectModal({
           </button>
           <button
             type="submit"
-            disabled={!name.trim()}
+            disabled={!name.trim() || createBoard.isPending}
             className="px-3 py-2 text-[12px] font-medium bg-gray-900 text-white rounded-lg hover:bg-gray-800 disabled:opacity-40 disabled:cursor-not-allowed transition-all"
           >
-            Create
+            {createBoard.isPending ? 'Creating...' : 'Create'}
           </button>
         </div>
       </form>


### PR DESCRIPTION
## Summary

- **CreateProjectModal**: wire existing `createBoard.isPending` from React Query to disable button and show "Creating..." during submission
- **MessagesView Create Channel**: add `isCreatingChannel` state to disable button and show "Creating..." during the async `addChannel` API call

Both modals previously awaited async API calls with no loading indicator, allowing double-submission and leaving the UI unresponsive during network round-trips.

## Test plan

- [ ] Create a new project — button should show "Creating..." and be disabled until API responds
- [ ] Create a new channel in Messages — same behavior
- [ ] Verify double-clicking the create button does not create duplicates
- [ ] Verify button re-enables if the API call fails

Closes #30

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate submissions during channel and project creation by disabling buttons and adding loading states.
  * Creation buttons now display "Creating..." feedback while operations complete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->