### PR TITLE
Paste images from clipboard into project card description

### DIFF
--- a/core-web/src/components/Projects/components/CardDetailModal.tsx
+++ b/core-web/src/components/Projects/components/CardDetailModal.tsx
@@ -152,7 +152,7 @@ export default function CardDetailModal({ card, onClose, initialEdit = false }: 
     );
     if (imageFile) {
       e.preventDefault();
-      uploadImageFile(imageFile);
+      void uploadImageFile(imageFile);
     }
   };
 


### PR DESCRIPTION
## Summary

- Extract image upload logic into reusable `uploadImageFile` helper
- Add `onPaste` handler to the card description textarea that detects clipboard images, uploads them, and adds to the Images section
- Normal text paste is unaffected. Only intercepts when clipboard contains an image

## Test plan

- [ ] Open a project card in edit mode
- [ ] Copy an image to clipboard (screenshot or copy from browser)
- [ ] Paste into the description textarea. Image should upload and appear in the Images section
- [ ] Paste plain text into the description. Should work normally
- [ ] Verify the + button still works for file picker uploads
- [ ] Verify uploaded pasted images persist after saving the card

Closes #23

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now paste images directly into card descriptions from their clipboard, streamlining image upload workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->