### PR TITLE
Show thinking indicator when returning to a chat with pending response

### DIFF
--- a/core-web/src/components/Chat/ChatView.tsx
+++ b/core-web/src/components/Chat/ChatView.tsx
@@ -243,11 +243,36 @@ export default function ChatView() {
 
     let pollTimer: ReturnType<typeof setInterval> | null = null;
     let pollTimeout: ReturnType<typeof setTimeout> | null = null;
+    let cancelled = false;
+
+    async function pollForReply(convId: string) {
+      if (cancelled) return;
+      try {
+        const data = await getMessages(convId);
+        if (data.at(-1)?.role === 'assistant') {
+          if (pollTimer) clearInterval(pollTimer);
+          if (pollTimeout) clearTimeout(pollTimeout);
+          setMessages(data.map((msg: Message) => ({
+            id: msg.id, role: msg.role, content: msg.content, content_parts: msg.content_parts,
+          })));
+          setIsWaitingForResponse(false);
+          requestAnimationFrame(() => {
+            const container = scrollContainerRef.current;
+            if (container) container.scrollTop = container.scrollHeight;
+          });
+        }
+      } catch {
+        if (pollTimer) clearInterval(pollTimer);
+        if (pollTimeout) clearTimeout(pollTimeout);
+        setIsWaitingForResponse(false);
+      }
+    }
 
     async function loadMessages() {
       setLoadingMessages(true);
       try {
         const data = await getMessages(urlConversationId!);
+        if (cancelled) return;
         setMessages(
           data.map((msg: Message) => ({
             id: msg.id,
@@ -264,56 +289,29 @@ export default function ChatView() {
           }
         });
 
-        // If the last message is a recent user message, show the
-        // thinking indicator and poll until the response appears.
-        const lastRaw = data[data.length - 1];
+        // If the last message is a recent user message, poll until
+        // it appears.
+        const lastRaw = data.at(-1);
         const isRecent = lastRaw?.created_at && (Date.now() - new Date(lastRaw.created_at).getTime()) < 60000;
-        if (lastRaw && lastRaw.role === 'user' && isRecent) {
+        if (lastRaw?.role === 'user' && isRecent) {
           setIsWaitingForResponse(true);
-          pollTimer = setInterval(async () => {
-            try {
-              const fresh = await getMessages(urlConversationId!);
-              const freshLast = fresh[fresh.length - 1];
-              if (freshLast && freshLast.role === 'assistant') {
-                if (pollTimer) clearInterval(pollTimer);
-                if (pollTimeout) clearTimeout(pollTimeout);
-                setMessages(
-                  fresh.map((msg: Message) => ({
-                    id: msg.id,
-                    role: msg.role,
-                    content: msg.content,
-                    content_parts: msg.content_parts,
-                  }))
-                );
-                setIsWaitingForResponse(false);
-                requestAnimationFrame(() => {
-                  const container = scrollContainerRef.current;
-                  if (container) {
-                    container.scrollTop = container.scrollHeight;
-                  }
-                });
-              }
-            } catch {
-              if (pollTimer) clearInterval(pollTimer);
-              setIsWaitingForResponse(false);
-            }
-          }, 5000);
-          // Stop polling after 60s
+          pollTimer = setInterval(() => pollForReply(urlConversationId!), 5000);
           pollTimeout = setTimeout(() => {
             if (pollTimer) clearInterval(pollTimer);
-            setIsWaitingForResponse(false);
+            if (!cancelled) setIsWaitingForResponse(false);
           }, 60000);
         }
       } catch (err) {
         console.error('Failed to load messages:', err);
       } finally {
-        setLoadingMessages(false);
+        if (!cancelled) setLoadingMessages(false);
       }
     }
 
     loadMessages();
 
     return () => {
+      cancelled = true;
       if (pollTimer) clearInterval(pollTimer);
       if (pollTimeout) clearTimeout(pollTimeout);
     };


### PR DESCRIPTION
## Summary

When you navigate away from chat while the AI is still responding and then come back, the message would appear to be gone. The backend keeps streaming and saves the response, but the UI had no way to show that something was still happening.

Now when you return to a conversation where the last message is yours and was sent recently (within 60s), the thinking dot indicator shows up and we poll the DB every 5s until the assistant response lands. Polling cleans up on navigation and caps at 60s.

Only affects conversations with recent unanswered messages, so old chats with no reply won't trigger it.

## Test plan

- [ ] Send a message to the AI agent, navigate to Projects before it finishes, then navigate back to Chat. Should see the thinking dot, then the response appears
- [ ] Open an old conversation where the last message is from you. Should NOT show the thinking dot
- [ ] Navigate away and back multiple times quickly. No duplicate polling or stale indicators

Closes #13

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chat responsiveness by polling for assistant replies after a recent user message (polls every ~5s) and updating the conversation in real time.
  * Added a 60-second fallback and robust cleanup to stop polling on navigation/unmount or errors, prevent stale state updates, and ensure the view scrolls to new assistant messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->