### PR TITLE
Clear streaming state when switching between conversations

### DIFF
--- a/core-web/src/components/Chat/ChatView.tsx
+++ b/core-web/src/components/Chat/ChatView.tsx
@@ -241,6 +241,14 @@ export default function ChatView() {
     // Set active conversation for sidebar highlighting
     setActiveConversationId(urlConversationId);
 
+    // Clear stale streaming state from previous conversation
+    streamingConversationRef.current = null;
+    builderRef.current = null;
+    setStreamingContent('');
+    setStreamingParts([]);
+    setStreamStatus(null);
+    setIsWaitingForResponse(false);
+
     async function loadMessages() {
       setLoadingMessages(true);
       try {


### PR DESCRIPTION
## Summary

When switching between chats while the AI is streaming a response, the streaming content from the first conversation would leak into whichever chat you switched to. This happened because the streaming UI state (content, parts, status) was never cleared when the conversation URL changed.

Added 6 lines to clear all streaming state at the top of the loadMessages effect, right when the conversation switches.

## Test plan

- [ ] Start a streaming response, switch to another chat. Old stream should disappear immediately
- [ ] Switch back to the original chat. Completed response should load from DB
- [ ] Start a new stream in the second chat. Should work normally with no leftover state

Closes #34

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where streaming content and status indicators from a previous conversation could persist when loading a different conversation. The chat now properly clears all streaming-related UI state when navigating to an existing conversation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->