### PR TITLE
Add "New Note" option to folder context menu

### DIFF
--- a/core-web/src/components/Files/FilesView.tsx
+++ b/core-web/src/components/Files/FilesView.tsx
@@ -1724,7 +1724,7 @@ export default function FilesView() {
     }
   };
 
-  const handleCreateNote = async () => {
+  const handleCreateNote = async (folderId?: string) => {
     setIsCreatingNote(true);
     isCreatingNoteRef.current = true;
 
@@ -1734,7 +1734,7 @@ export default function FilesView() {
     setShouldFocusTitle(true);
 
     try {
-      const newNote = await addNote(currentFolderId);
+      const newNote = await addNote(folderId ?? currentFolderId);
       if (newNote) {
         // Update ref so subsequent loads work correctly
         lastLoadedNoteIdRef.current = newNote.id;
@@ -2235,6 +2235,18 @@ export default function FilesView() {
                                           onClose={() => setOpenItemMenuId(null)}
                                           trigger={{ current: itemMenuRefs.current.get(item.id) || null }}
                                         >
+                                          <button
+                                            onClick={(e) => {
+                                              e.stopPropagation();
+                                              setOpenItemMenuId(null);
+                                              handleCreateNote(item.id);
+                                            }}
+                                            disabled={isCreatingNote}
+                                            className="w-full px-3 py-1.5 text-left text-sm text-text-body hover:bg-bg-gray flex items-center gap-2 disabled:opacity-50"
+                                          >
+                                            <Icon icon={Plus} size={14} />
+                                            New Note
+                                          </button>
                                           <button
                                             onClick={(e) => { e.stopPropagation(); handleRenameItem(item); }}
                                             className="w-full px-3 py-1.5 text-left text-sm text-text-body hover:bg-bg-gray flex items-center gap-2"
@@ -2813,7 +2825,7 @@ export default function FilesView() {
                       Select a note or create a new one
                     </p>
                     <button
-                      onClick={handleCreateNote}
+                      onClick={() => handleCreateNote()}
                       disabled={isCreatingNote}
                       className="mt-4 flex items-center gap-2 px-4 py-2 text-sm font-medium text-text-light bg-brand-primary hover:opacity-90 rounded-lg transition-opacity disabled:opacity-50 mx-auto"
                     >

--- a/core-web/src/stores/filesStore.ts
+++ b/core-web/src/stores/filesStore.ts
@@ -565,14 +565,9 @@ export const useFilesStore = create<FilesState>()(
     const key = folderKey(parentId);
 
     // Add optimistic note to store immediately
-    // Also add to root cache so it appears in "All" view instantly
     set((state) => {
       const updated = { ...state.documentsByFolder };
       updated[key] = [optimisticNote, ...(updated[key] || [])];
-      // If creating in a subfolder, also add to root so "All" view updates immediately
-      if (parentId && updated[ROOT_KEY]) {
-        updated[ROOT_KEY] = [optimisticNote, ...updated[ROOT_KEY]];
-      }
       return {
         documentsByFolder: updated,
         selectedNoteId: tempId,
@@ -596,12 +591,6 @@ export const useFilesStore = create<FilesState>()(
         updated[key] = updated[key].map(d =>
           d.id === tempId ? realNote : d
         );
-        // Also update in root cache if it exists there
-        if (parentId && updated[ROOT_KEY]) {
-          updated[ROOT_KEY] = updated[ROOT_KEY].map(d =>
-            d.id === tempId ? realNote : d
-          );
-        }
         return {
           documentsByFolder: updated,
           // Update selectedNoteId if it was the temp note
@@ -614,10 +603,6 @@ export const useFilesStore = create<FilesState>()(
       set((state) => {
         const updated = { ...state.documentsByFolder };
         updated[key] = updated[key].filter(d => d.id !== tempId);
-        // Also remove from root cache if it was added there
-        if (parentId && updated[ROOT_KEY]) {
-          updated[ROOT_KEY] = updated[ROOT_KEY].filter(d => d.id !== tempId);
-        }
         return {
           documentsByFolder: updated,
           selectedNoteId: state.selectedNoteId === tempId ? null : state.selectedNoteId,


### PR DESCRIPTION


https://github.com/user-attachments/assets/62713a84-c5c5-496e-b64a-e2a5eddbcbff


## Summary

- Add "New Note" button to the folder right-click/three-dot menu so you can create notes directly inside a folder without navigating into it first
- The editor opens with title focused, same as creating from the top-level "New" button
- Fix pre-existing bug where creating a note inside a subfolder would show a duplicate at root level (the store was optimistically adding subfolder items to the root cache, but the API never returns them there)

## Test plan

- [ ] Right-click a folder, click "New Note". Note should appear inside the folder and editor should open with title focused
- [ ] Create a note from the top-level "New" button. Should still work the same as before
- [ ] Create a note inside a subfolder while viewing root. Should NOT show a duplicate at root level
- [ ] Move a file between folders. Should not cause duplicates
- [ ] Refresh the page after creating notes in subfolders. Everything should persist correctly

Closes #36

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "New Note" button to folder context menus for creating notes directly within a specific folder.
  * Improved note creation to respect the folder context where the action is initiated, rather than always using the currently selected folder.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->