### PR TITLE
fix: text-only channel message failures when R2 is not configured

### DIFF
--- a/core-api/api/services/messages/messages.py
+++ b/core-api/api/services/messages/messages.py
@@ -519,6 +519,15 @@ async def _enrich_messages_with_file_urls_legacy(messages: List[Dict[str, Any]],
     if not messages:
         return
 
+    has_file_blocks = any(
+        isinstance(block, dict) and block.get("type") == "file"
+        for msg in messages
+        for block in (msg.get("blocks") or [])
+        if isinstance(msg.get("blocks"), list)
+    )
+    if not has_file_blocks:
+        return
+
     admin = await get_async_service_role_client()
     r2 = get_r2_client()
 

--- a/core-api/tests/messages/test_message_file_enrichment.py
+++ b/core-api/tests/messages/test_message_file_enrichment.py
@@ -1,0 +1,64 @@
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+
+from tests.conftest import MockAPIResponse, _create_async_query_builder
+
+
+@pytest.mark.asyncio
+async def test_legacy_enrichment_skips_text_only_messages(monkeypatch):
+    from api.services.messages import messages as mod
+
+    monkeypatch.setattr(
+        mod,
+        "get_async_service_role_client",
+        AsyncMock(side_effect=AssertionError("service role client should not be used")),
+    )
+    monkeypatch.setattr(
+        mod,
+        "get_r2_client",
+        MagicMock(side_effect=AssertionError("R2 client should not be initialized")),
+    )
+
+    messages = [{
+        "id": "msg-1",
+        "channel_id": "channel-1",
+        "blocks": [{"type": "text", "data": {"content": "hello"}}],
+    }]
+
+    await mod._enrich_messages_with_file_urls_legacy(messages, "jwt")
+
+
+@pytest.mark.asyncio
+async def test_get_message_skips_r2_for_text_only_messages(monkeypatch):
+    from api.services.messages import messages as mod
+
+    message = {
+        "id": "msg-1",
+        "channel_id": "channel-1",
+        "user_id": "user-1",
+        "blocks": [{"type": "text", "data": {"content": "hello"}}],
+    }
+
+    client = MagicMock()
+    query_builder = _create_async_query_builder(MockAPIResponse(data=[message]))
+    client.table.return_value = query_builder
+
+    monkeypatch.setattr(mod, "get_authenticated_async_client", AsyncMock(return_value=client))
+    monkeypatch.setattr(mod, "attach_public_profiles", AsyncMock())
+    monkeypatch.setattr(mod.settings, "image_proxy_url", "")
+    monkeypatch.setattr(mod.settings, "image_proxy_secret", "")
+    monkeypatch.setattr(
+        mod,
+        "get_async_service_role_client",
+        AsyncMock(side_effect=AssertionError("service role client should not be used")),
+    )
+    monkeypatch.setattr(
+        mod,
+        "get_r2_client",
+        MagicMock(side_effect=AssertionError("R2 client should not be initialized")),
+    )
+
+    result = await mod.get_message("msg-1", "jwt")
+
+    assert result is not None
+    assert result["id"] == "msg-1"


### PR DESCRIPTION
## Summary

Fixes https://github.com/10xapp/core-oss/issues/39.

This change fixes channel message response hydration for local/self-hosted setups where R2 and the image proxy are not configured.

For text-only messages, the legacy file enrichment path was initializing the R2 client before checking whether any `file` blocks were present. With an empty `R2_S3_API`, that raised `Invalid endpoint: ` and caused the message request to return `400 Bad Request` even though the message row had already been written.

## What changed

- return early from legacy message file enrichment when there are no `file` blocks
- avoid initializing the R2 client for text-only messages
- add regression tests covering text-only message fetch/enrichment behavior

## Why

Text-only channel messages should not depend on R2 configuration. This keeps the message path working in local and self-hosted environments that do not use file storage.

## Testing

- `uv run --with-requirements requirements-dev.txt python -m pytest tests/messages/test_message_file_enrichment.py`

## Scope

This PR is intentionally focused on the direct root cause in the legacy file enrichment path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Message enrichment now skips unnecessary resource initialization when processing text-only messages, improving efficiency.

* **Tests**
  * Added test coverage validating that resource-intensive operations are bypassed for text-only message content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->