### PR TITLE
fix: correct project board cache invalidation and add realtime listeners

### DIFF
--- a/core-web/src/components/Projects/ProjectsView.tsx
+++ b/core-web/src/components/Projects/ProjectsView.tsx
@@ -5,6 +5,7 @@ import { useProjectsStore } from "../../stores/projectsStore";
 import { useProjectBoards, usePrefetchBoards } from "../../hooks/queries/useProjects";
 import { updateProjectBoard, deleteProjectBoard } from "../../api/client";
 import { useQueryClient } from "@tanstack/react-query";
+import { projectKeys } from "../../hooks/queries/keys";
 import ProjectSidebar from "./components/ProjectSidebar";
 import KanbanBoard from "./components/KanbanBoard";
 import CreateProjectModal from "./components/CreateProjectModal";
@@ -107,15 +108,13 @@ export default function ProjectsView() {
   const handleSaveBoardSettings = useCallback(async (name: string, description: string) => {
     if (!activeProjectId) return;
     await updateProjectBoard(activeProjectId, { name, description });
-    // Invalidate boards query to refresh the list
-    queryClient.invalidateQueries({ queryKey: ["project-boards", workspaceAppId] });
+    queryClient.invalidateQueries({ queryKey: projectKeys.boards(workspaceAppId ?? '') });
   }, [activeProjectId, workspaceAppId, queryClient]);
 
   const handleDeleteBoard = useCallback(async () => {
     if (!activeProjectId || !workspaceId) return;
     await deleteProjectBoard(activeProjectId);
-    // Invalidate and navigate to first remaining board or empty state
-    queryClient.invalidateQueries({ queryKey: ["project-boards", workspaceAppId] });
+    queryClient.invalidateQueries({ queryKey: projectKeys.boards(workspaceAppId ?? '') });
     setActiveProject(null);
     navigate(`/workspace/${workspaceId}/projects`);
   }, [activeProjectId, workspaceAppId, workspaceId, queryClient, navigate, setActiveProject]);

--- a/core-web/src/hooks/useGlobalRealtime.ts
+++ b/core-web/src/hooks/useGlobalRealtime.ts
@@ -837,6 +837,100 @@ export function useGlobalRealtime(enabled = true) {
       )
 
       // ================================================================
+      // project_boards INSERT/UPDATE/DELETE → invalidate boards list
+      // ================================================================
+      .on(
+        'postgres_changes',
+        { event: 'INSERT', schema: 'public', table: 'project_boards' },
+        (payload) => {
+          recordRealtimeEvent();
+          const board = payload.new as { workspace_app_id?: string };
+          if (board.workspace_app_id) {
+            queryClientRef.current.invalidateQueries({
+              queryKey: projectKeys.boards(board.workspace_app_id),
+            });
+          }
+        }
+      )
+      .on(
+        'postgres_changes',
+        { event: 'UPDATE', schema: 'public', table: 'project_boards' },
+        (payload) => {
+          recordRealtimeEvent();
+          const board = payload.new as { id?: string; workspace_app_id?: string };
+          if (board.workspace_app_id) {
+            queryClientRef.current.invalidateQueries({
+              queryKey: projectKeys.boards(board.workspace_app_id),
+            });
+          }
+          if (board.id) {
+            queryClientRef.current.invalidateQueries({
+              queryKey: projectKeys.board(board.id),
+            });
+          }
+        }
+      )
+      .on(
+        'postgres_changes',
+        { event: 'DELETE', schema: 'public', table: 'project_boards' },
+        (payload) => {
+          recordRealtimeEvent();
+          const board = payload.old as { workspace_app_id?: string };
+          if (board.workspace_app_id) {
+            queryClientRef.current.invalidateQueries({
+              queryKey: projectKeys.boards(board.workspace_app_id),
+            });
+          }
+        }
+      )
+
+      // ================================================================
+      // project_issues INSERT/UPDATE/DELETE → invalidate board data
+      // ================================================================
+      .on(
+        'postgres_changes',
+        { event: 'INSERT', schema: 'public', table: 'project_issues' },
+        (payload) => {
+          recordRealtimeEvent();
+          const issue = payload.new as { board_id?: string; user_id?: string };
+          // Skip own mutations — optimistic updates already handle them
+          if (issue.user_id === currentUserIdRef.current) return;
+          if (issue.board_id) {
+            queryClientRef.current.invalidateQueries({
+              queryKey: projectKeys.boardData(issue.board_id),
+            });
+          }
+        }
+      )
+      .on(
+        'postgres_changes',
+        { event: 'UPDATE', schema: 'public', table: 'project_issues' },
+        (payload) => {
+          recordRealtimeEvent();
+          const issue = payload.new as { board_id?: string; user_id?: string };
+          if (issue.user_id === currentUserIdRef.current) return;
+          if (issue.board_id) {
+            queryClientRef.current.invalidateQueries({
+              queryKey: projectKeys.boardData(issue.board_id),
+            });
+          }
+        }
+      )
+      .on(
+        'postgres_changes',
+        { event: 'DELETE', schema: 'public', table: 'project_issues' },
+        (payload) => {
+          recordRealtimeEvent();
+          const issue = payload.old as { board_id?: string };
+          if (issue.board_id) {
+            queryClientRef.current.invalidateQueries({
+              queryKey: projectKeys.boardData(issue.board_id),
+            });
+          }
+        }
+      )
+
+      // ================================================================
       // notifications INSERT → notification bell + toast
       // ================================================================
       .on(


### PR DESCRIPTION
## Summary

- **Bug fix:** `ProjectsView` was calling `invalidateQueries` with a hardcoded key `["project-boards", workspaceAppId]` that never matched anything in the React Query cache. The correct key from `projectKeys.boards()` is `['projects', 'boards', workspaceAppId]`. Because the invalidation was a no-op, renaming or deleting a board wouldn't refresh the boards list until the 2-minute `staleTime` expired naturally — and since the persisted localStorage cache was also never cleared, even a page reload wouldn't help.

- **Realtime:** `useGlobalRealtime` had listeners for comments and reactions on project issues, but no listeners for `project_boards` or `project_issues` themselves. Added INSERT/UPDATE/DELETE handlers for both tables so board list and issue state stay live across users without a manual refresh.

## Files changed

- `core-web/src/components/Projects/ProjectsView.tsx` — import `projectKeys` and use it for both `invalidateQueries` calls
- `core-web/src/hooks/useGlobalRealtime.ts` — add realtime listeners for `project_boards` and `project_issues`

## Test plan

- [ ] Create a new project board — it should appear in the sidebar immediately
- [ ] Rename a board via settings — the sidebar name should update immediately
- [ ] Delete a board — it should disappear from the sidebar immediately, with navigation to projects root
- [ ] With two browser tabs open: create/rename/delete a board in one tab and confirm the other tab reflects the change without refreshing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced real-time data synchronization for project boards and issues to ensure information remains current across the application
  * Improved cache management to prevent stale data when working with projects and boards
  * Optimized data consistency handling to reduce redundant operations during collaborative editing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->