### PR TITLE
fix: unauthenticated Gmail/Calendar webhooks, OAuth identity spoof, and avatar SSRF

### DIFF
--- a/core-api/api/config.py
+++ b/core-api/api/config.py
@@ -109,6 +109,14 @@ class Settings(BaseSettings):
     google_cloud_project_id: str = ""
     google_pubsub_topic: str = ""  # Full topic path: projects/PROJECT_ID/topics/TOPIC_NAME
 
+    # Service account email Google signs Pub/Sub push tokens with. Required to
+    # verify the OIDC bearer on /api/webhooks/gmail and /api/webhooks/calendar.
+    # Configured per-subscription in GCP ("Authentication" -> "Service account").
+    pubsub_push_service_account: str = ""
+    # Audience the OIDC token is signed for. Defaults to webhook_base_url + path.
+    # Override if your Pub/Sub subscription uses a different audience string.
+    pubsub_push_audience: str = ""
+
     # Microsoft OAuth settings (for Outlook/Microsoft 365 sync)
     microsoft_client_id: str = ""
     microsoft_client_secret: str = ""

--- a/core-api/api/routers/webhooks.py
+++ b/core-api/api/routers/webhooks.py
@@ -2,13 +2,14 @@
 Webhooks router - Receives push notifications from external services
 Thin layer that handles HTTP concerns and delegates to services.
 """
-from fastapi import APIRouter, Request, Header, Query, Response
+from fastapi import APIRouter, Request, Header, Query, Response, HTTPException, status
 from fastapi.responses import PlainTextResponse
 from typing import Optional
 import asyncio
 import logging
 import json
 import base64
+import re
 from datetime import datetime, timezone
 
 from api.services.webhooks import (
@@ -16,6 +17,7 @@ from api.services.webhooks import (
     process_calendar_notification
 )
 from lib.token_encryption import decrypt_ext_connection_tokens
+from lib.webhook_auth import PubSubAuthError, verify_pubsub_push
 
 from pydantic import BaseModel
 from api.schemas import HealthResponse
@@ -65,12 +67,20 @@ async def gmail_webhook(request: Request):
     Returns 200 immediately to acknowledge receipt (required by Pub/Sub).
     """
     try:
+        try:
+            verify_pubsub_push(request)
+        except PubSubAuthError as auth_err:
+            # Don't 401 — Pub/Sub treats non-2xx as delivery failure and would
+            # retry the spoofed message with backoff. Drop silently and log.
+            logger.warning(f"⚠️ Gmail webhook: rejecting unauthenticated push ({auth_err})")
+            return {"status": "ok"}
+
         # Parse Pub/Sub message format
         body = await request.json()
-        
+
         logger.info("📬 Gmail webhook received")
         logger.debug(f"Body keys: {body.keys() if body else 'empty'}")
-        
+
         # Validate Pub/Sub message format
         if not body.get('message') or not body['message'].get('data'):
             logger.error(f"❌ Invalid Pub/Sub message format: {body}")
@@ -166,6 +176,12 @@ async def calendar_webhook(
     Returns 200 immediately to acknowledge receipt (required by Google).
     """
     try:
+        try:
+            verify_pubsub_push(request)
+        except PubSubAuthError as auth_err:
+            logger.warning(f"⚠️ Calendar webhook: rejecting unauthenticated push ({auth_err})")
+            return {"status": "ok"}
+
         logger.info(f"📅 Calendar webhook received: channel={x_goog_channel_id}, state={x_goog_resource_state}")
 
         # Try to enqueue via QStash for async processing
@@ -248,6 +264,11 @@ async def verify_calendar_webhook():
 
 # ============== Microsoft Graph Webhooks ==============
 
+# Microsoft Graph validation tokens are URL-safe and bounded; reject anything
+# outside that shape so the endpoint can't be used as a generic reflector.
+_MS_VALIDATION_TOKEN_RE = re.compile(r"^[A-Za-z0-9_\-]{1,1024}$")
+
+
 @router.get("/microsoft", response_class=PlainTextResponse, responses={
     200: {"description": "Validation token echo", "content": {"text/plain": {"schema": {"type": "string"}}}},
 })
@@ -261,8 +282,10 @@ async def microsoft_webhook_validation(
     validationToken query parameter. We MUST return the token as plain text
     within 10 seconds or subscription creation fails.
     """
+    if not _MS_VALIDATION_TOKEN_RE.match(validationToken):
+        logger.warning("📡 [Microsoft] Rejected validation token (bad shape)")
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="invalid validation token")
     logger.info("📡 [Microsoft] Subscription validation request received")
-    logger.debug(f"📡 [Microsoft] Validation token: {validationToken[:20]}...")
     return PlainTextResponse(
         content=validationToken,
         status_code=200,
@@ -290,6 +313,9 @@ async def microsoft_webhook_notification(
         # Microsoft may send validation as POST with ?validationToken= query param
         validation_token = request.query_params.get("validationToken")
         if validation_token:
+            if not _MS_VALIDATION_TOKEN_RE.match(validation_token):
+                logger.warning("📡 [Microsoft] Rejected validation token (bad shape)")
+                return Response(status_code=400)
             logger.info("📡 [Microsoft] Subscription validation via POST request")
             return PlainTextResponse(
                 content=validation_token,
@@ -419,11 +445,10 @@ async def process_microsoft_notification(notification: dict) -> dict:
     from api.services.microsoft.microsoft_webhook_provider import MicrosoftWebhookProvider
 
     subscription_id = notification.get('subscriptionId')
-    client_state = notification.get('clientState')
     change_type = notification.get('changeType')
     resource = notification.get('resource', '')
 
-    logger.info(f"📬 [Microsoft] Notification: {change_type} on {resource[:50]}... (clientState: {'✓' if client_state else '✗'})")
+    logger.info(f"📬 [Microsoft] Notification received: {change_type} on {resource[:50]}...")
 
     if not subscription_id:
         logger.warning("⚠️ [Microsoft] No subscriptionId in notification")

--- a/core-api/api/services/auth.py
+++ b/core-api/api/services/auth.py
@@ -8,7 +8,10 @@ Supports multiple OAuth providers:
 from typing import Dict, Any, List, Optional
 from io import BytesIO
 from datetime import datetime
+from urllib.parse import urlparse
 import asyncio
+import ipaddress
+import socket
 import uuid
 import logging
 
@@ -263,6 +266,36 @@ async def _enqueue_or_fallback_microsoft_initial_sync(
     )
 
 
+# Hosts we accept avatar downloads from. Anything else is rejected before
+# we issue an HTTP request, so the function can't be turned into an SSRF gadget.
+_AVATAR_HOST_SUFFIXES = (".googleusercontent.com",)
+_AVATAR_HOST_EXACT = ("graph.microsoft.com",)
+
+
+def _is_safe_avatar_url(url: str) -> bool:
+    parsed = urlparse(url)
+    if parsed.scheme != "https":
+        return False
+    host = (parsed.hostname or "").lower()
+    if not host:
+        return False
+    if host not in _AVATAR_HOST_EXACT and not any(host.endswith(s) for s in _AVATAR_HOST_SUFFIXES):
+        return False
+    try:
+        infos = socket.getaddrinfo(host, None)
+    except socket.gaierror:
+        return False
+    for family, _, _, _, sockaddr in infos:
+        addr = sockaddr[0]
+        try:
+            ip = ipaddress.ip_address(addr)
+        except ValueError:
+            return False
+        if ip.is_private or ip.is_loopback or ip.is_link_local or ip.is_reserved or ip.is_multicast:
+            return False
+    return True
+
+
 async def _download_avatar_to_r2(avatar_url: Optional[str], user_id: str) -> Optional[str]:
     """Download an external avatar image and upload it to the R2 public bucket.
 
@@ -271,9 +304,13 @@ async def _download_avatar_to_r2(avatar_url: Optional[str], user_id: str) -> Opt
     if not avatar_url or not settings.r2_public_access_url:
         return None
 
+    if not _is_safe_avatar_url(avatar_url):
+        logger.warning(f"⚠️ Rejected avatar URL (host or scheme not allowed): {avatar_url[:80]}")
+        return None
+
     try:
         async with httpx.AsyncClient() as client:
-            resp = await client.get(avatar_url, timeout=10, follow_redirects=True)
+            resp = await client.get(avatar_url, timeout=10, follow_redirects=False)
         resp.raise_for_status()
 
         content_type = resp.headers.get('content-type', 'image/png').split(';')[0]
@@ -555,6 +592,30 @@ class AuthService:
                 raise
         elif not access_token:
             logger.warning(f"⚠️ [{provider}] No access_token or server_auth_code provided")
+
+        # Re-derive identity from the access_token. provider_user_id, name,
+        # avatar_url, and the email tied to the token must come from the
+        # provider, not the request body — otherwise an authenticated user
+        # can shadow-link the connection to someone else's account.
+        if access_token:
+            try:
+                provider_identity = get_user_info(access_token, provider=provider)
+            except ValueError:
+                logger.warning(f"⚠️ [{provider}] could not verify identity from access_token")
+                raise
+
+            provider_email = (provider_identity.get('email') or '').strip().lower()
+            if not provider_email or provider_email != (email or '').strip().lower():
+                logger.warning(f"⚠️ [{provider}] access_token email does not match authenticated user")
+                raise ValueError("access_token does not belong to the authenticated user")
+
+            provider_user_id = provider_identity.get('id')
+            if not provider_user_id:
+                raise ValueError("provider did not return a user id")
+
+            oauth_data['provider_user_id'] = provider_user_id
+            oauth_data['name'] = provider_identity.get('name')
+            oauth_data['avatar_url'] = provider_identity.get('picture')
 
         # Use authenticated Supabase client (respects RLS policies)
         auth_supabase = get_authenticated_supabase_client(user_jwt)

--- a/core-api/api/services/microsoft/microsoft_webhook_provider.py
+++ b/core-api/api/services/microsoft/microsoft_webhook_provider.py
@@ -10,6 +10,7 @@ Key differences from Google:
 - Max expiration: 4230 minutes (~3 days) for mail, 10080 minutes (7 days) for calendar
 """
 from typing import Dict, Any
+import hmac
 import logging
 import secrets
 import httpx
@@ -370,11 +371,14 @@ class MicrosoftWebhookProvider:
         notification_client_state = request_data.get('clientState')
         stored_client_state = subscription_data.get('client_state')
 
-        if not stored_client_state:
-            logger.warning("[Microsoft] No client_state stored for subscription")
+        if not stored_client_state or not notification_client_state:
+            logger.warning("[Microsoft] Missing client_state on notification or subscription")
             return False
 
-        if notification_client_state != stored_client_state:
+        if not hmac.compare_digest(
+            str(notification_client_state).encode("utf-8"),
+            str(stored_client_state).encode("utf-8"),
+        ):
             logger.warning("[Microsoft] clientState mismatch - possible spoofed notification")
             return False
 

--- a/core-api/lib/webhook_auth.py
+++ b/core-api/lib/webhook_auth.py
@@ -1,0 +1,68 @@
+"""
+Verification of Google Cloud Pub/Sub push notifications.
+
+Pub/Sub push subscriptions configured with a service-account auth send an
+Authorization: Bearer <ID token> header on every delivery. We verify that
+token against Google's public keys and the configured service account.
+"""
+import logging
+from typing import Optional
+
+from fastapi import Request
+from google.auth.transport import requests as gauth_requests
+from google.oauth2 import id_token
+
+from api.config import settings
+
+logger = logging.getLogger(__name__)
+
+_request_adapter = gauth_requests.Request()
+
+
+class PubSubAuthError(Exception):
+    """Raised when a Pub/Sub push request cannot be authenticated."""
+
+
+def _expected_audience(request: Request) -> str:
+    if settings.pubsub_push_audience:
+        return settings.pubsub_push_audience
+    if settings.webhook_base_url:
+        return settings.webhook_base_url.rstrip("/") + request.url.path
+    # Last resort: use the absolute URL the proxy forwarded.
+    return str(request.url).split("?", 1)[0]
+
+
+def verify_pubsub_push(request: Request) -> None:
+    """
+    Validate a Pub/Sub push request. Raises PubSubAuthError on any failure.
+
+    Caller is responsible for translating that into the appropriate response
+    (Pub/Sub semantics: return HTTP 200 + log on bad tokens to avoid retry
+    storms; non-200 makes Pub/Sub keep redelivering).
+    """
+    sa = settings.pubsub_push_service_account
+    if not sa:
+        # Verification not configured. Treat as a hard failure so we don't
+        # silently fall back to "anyone can post" if the env is missing.
+        raise PubSubAuthError("pubsub_push_service_account is not configured")
+
+    auth_header: Optional[str] = request.headers.get("Authorization") or request.headers.get("authorization")
+    if not auth_header or not auth_header.lower().startswith("bearer "):
+        raise PubSubAuthError("missing bearer token")
+
+    token = auth_header.split(" ", 1)[1].strip()
+    if not token:
+        raise PubSubAuthError("empty bearer token")
+
+    audience = _expected_audience(request)
+
+    try:
+        claims = id_token.verify_oauth2_token(token, _request_adapter, audience=audience)
+    except Exception as exc:
+        raise PubSubAuthError(f"token verification failed: {exc}") from exc
+
+    if claims.get("email") != sa:
+        raise PubSubAuthError(f"unexpected token issuer: {claims.get('email')!r}")
+
+    if claims.get("email_verified") is not True:
+        raise PubSubAuthError("token issuer email is not verified")

--- a/core-api/tests/unit/test_avatar_url_guard.py
+++ b/core-api/tests/unit/test_avatar_url_guard.py
@@ -1,0 +1,29 @@
+"""Tests for the avatar URL allowlist used before downloading."""
+import pytest
+
+from api.services.auth import _is_safe_avatar_url
+
+
+@pytest.mark.parametrize("url", [
+    "https://lh3.googleusercontent.com/a/AAAA",
+    "https://lh4.googleusercontent.com/a/BBBB",
+    "https://graph.microsoft.com/v1.0/me/photo/$value",
+])
+def test_allows_known_provider_hosts(url):
+    assert _is_safe_avatar_url(url) is True
+
+
+@pytest.mark.parametrize("url", [
+    "http://lh3.googleusercontent.com/a/AAAA",       # http instead of https
+    "ftp://lh3.googleusercontent.com/a/AAAA",        # non-http scheme
+    "https://evil.com/avatar.png",                   # not on allowlist
+    "https://googleusercontent.com.evil.com/x",      # suffix-confusion
+    "https://127.0.0.1/a",                           # loopback
+    "https://10.0.0.1/admin",                        # rfc1918
+    "https://169.254.169.254/latest/meta-data/",     # cloud metadata
+    "https://[::1]/a",                               # ipv6 loopback
+    "",                                              # empty
+    "not a url",
+])
+def test_rejects_unsafe_urls(url):
+    assert _is_safe_avatar_url(url) is False

--- a/core-api/tests/unit/test_microsoft_webhook_validate.py
+++ b/core-api/tests/unit/test_microsoft_webhook_validate.py
@@ -1,0 +1,41 @@
+"""Tests for MicrosoftWebhookProvider.validate_notification."""
+import pytest
+
+from api.services.microsoft.microsoft_webhook_provider import MicrosoftWebhookProvider
+
+
+@pytest.fixture
+def provider():
+    return MicrosoftWebhookProvider()
+
+
+def test_accepts_matching_client_state(provider):
+    notification = {"clientState": "abc123"}
+    subscription = {"client_state": "abc123"}
+    assert provider.validate_notification(notification, subscription) is True
+
+
+def test_rejects_mismatched_client_state(provider):
+    notification = {"clientState": "abc123"}
+    subscription = {"client_state": "xyz789"}
+    assert provider.validate_notification(notification, subscription) is False
+
+
+def test_rejects_missing_client_state_on_notification(provider):
+    notification = {}
+    subscription = {"client_state": "abc123"}
+    assert provider.validate_notification(notification, subscription) is False
+
+
+def test_rejects_missing_client_state_on_subscription(provider):
+    notification = {"clientState": "abc123"}
+    subscription = {}
+    assert provider.validate_notification(notification, subscription) is False
+
+
+def test_constant_time_compare_handles_unequal_lengths(provider):
+    # hmac.compare_digest only fails on equal-length inputs in some libraries.
+    # Make sure unequal-length values are rejected without raising.
+    notification = {"clientState": "short"}
+    subscription = {"client_state": "much-longer-secret-value"}
+    assert provider.validate_notification(notification, subscription) is False

--- a/core-api/tests/unit/test_pubsub_webhook_auth.py
+++ b/core-api/tests/unit/test_pubsub_webhook_auth.py
@@ -1,0 +1,71 @@
+"""Tests for the Pub/Sub push verification helper."""
+from unittest.mock import patch
+
+import pytest
+from fastapi import Request
+
+from lib import webhook_auth
+from lib.webhook_auth import PubSubAuthError, verify_pubsub_push
+
+
+def _request(headers=None, path="/api/webhooks/gmail"):
+    headers = headers or {}
+    scope = {
+        "type": "http",
+        "method": "POST",
+        "path": path,
+        "raw_path": path.encode(),
+        "query_string": b"",
+        "headers": [(k.lower().encode(), v.encode()) for k, v in headers.items()],
+        "scheme": "http",
+        "server": ("testserver", 80),
+    }
+    return Request(scope)
+
+
+def test_rejects_when_service_account_not_configured():
+    with patch.object(webhook_auth.settings, "pubsub_push_service_account", ""):
+        with pytest.raises(PubSubAuthError, match="not configured"):
+            verify_pubsub_push(_request({"Authorization": "Bearer x"}))
+
+
+def test_rejects_missing_bearer_header():
+    with patch.object(webhook_auth.settings, "pubsub_push_service_account", "sa@example.iam.gserviceaccount.com"):
+        with pytest.raises(PubSubAuthError, match="missing bearer token"):
+            verify_pubsub_push(_request({}))
+
+
+def test_rejects_bad_token():
+    with patch.object(webhook_auth.settings, "pubsub_push_service_account", "sa@example.iam.gserviceaccount.com"), \
+         patch.object(webhook_auth.settings, "pubsub_push_audience", "https://api.example.com/api/webhooks/gmail"), \
+         patch.object(webhook_auth.id_token, "verify_oauth2_token", side_effect=ValueError("bad signature")):
+        with pytest.raises(PubSubAuthError, match="token verification failed"):
+            verify_pubsub_push(_request({"Authorization": "Bearer junk"}))
+
+
+def test_rejects_token_from_unexpected_service_account():
+    claims = {"email": "someone-else@example.iam.gserviceaccount.com", "email_verified": True}
+    with patch.object(webhook_auth.settings, "pubsub_push_service_account", "sa@example.iam.gserviceaccount.com"), \
+         patch.object(webhook_auth.settings, "pubsub_push_audience", "https://api.example.com/api/webhooks/gmail"), \
+         patch.object(webhook_auth.id_token, "verify_oauth2_token", return_value=claims):
+        with pytest.raises(PubSubAuthError, match="unexpected token issuer"):
+            verify_pubsub_push(_request({"Authorization": "Bearer good"}))
+
+
+def test_accepts_valid_token():
+    sa = "sa@example.iam.gserviceaccount.com"
+    claims = {"email": sa, "email_verified": True}
+    with patch.object(webhook_auth.settings, "pubsub_push_service_account", sa), \
+         patch.object(webhook_auth.settings, "pubsub_push_audience", "https://api.example.com/api/webhooks/gmail"), \
+         patch.object(webhook_auth.id_token, "verify_oauth2_token", return_value=claims):
+        verify_pubsub_push(_request({"Authorization": "Bearer good"}))
+
+
+def test_rejects_unverified_email_claim():
+    sa = "sa@example.iam.gserviceaccount.com"
+    claims = {"email": sa, "email_verified": False}
+    with patch.object(webhook_auth.settings, "pubsub_push_service_account", sa), \
+         patch.object(webhook_auth.settings, "pubsub_push_audience", "https://api.example.com/api/webhooks/gmail"), \
+         patch.object(webhook_auth.id_token, "verify_oauth2_token", return_value=claims):
+        with pytest.raises(PubSubAuthError, match="email is not verified"):
+            verify_pubsub_push(_request({"Authorization": "Bearer good"}))


### PR DESCRIPTION
The core-api handles inbound requests from google, microsoft, and the oauth callback i found 5 bugs that are all reproducible with curl against a local supabase stack, the gmail webhook accepted any unauthenticated POST. you can forge a pub/sub shaped body and the server will run a real query against push_subscriptions with whatever email you put in:

```bash
  PAYLOAD='{"emailAddress":"victim@example.com","historyId":"99999999"}'
  B64=$(printf '%s' "$PAYLOAD" | base64 -w0)
  curl -i -X POST http://localhost:8000/api/webhooks/gmail \
    -H 'Content-Type: application/json' \
    -d "{\"message\":{\"data\":\"$B64\",\"messageId\":\"x\"},\"subscription\":\"projects/fake/subscriptions/attacker\"}"
```

returns 200, server logs show `GET .../push_subscriptions?...&ext_connections.provider_email=eq.victim%40example.com` from the attacker controlled email. the calendar webhook had the same hole, just send  it `-d '{}'` and it processes the dispatch. the fix: pub/sub configured with a service account sends a google signed oidc bearer on every push, we now verify that token against `pubsub_push_service_account` before touching anything. if it doesn't check out we still return 200 with a log warning instead of 401, otherwise pub/sub will keep retrying the forged message with exponential backoff. The microsoft webhook compared clientState with plain `!=` which leaks timing, and the validation handshake endpoint reflected literally any input back as text/plain:

```bash
  curl -i 'http://localhost:8000/api/webhooks/microsoft?validationToken=ARBITRARY_<script>alert(1)</script>'
```

echoes the script tag right back. swapped the compare to hmac.compare_digest, locked validationToken down to `[A-Za-z0-9_-]{1,1024}`, and removed a log line that printed a clientState checkmark before validation had actually happened, it was always green even for forged notifications.

the bigger one was `/api/auth/complete-oauth`. it accepted client supplied provider_user_id, name, avatar_url, and access_token and persisted them without ever calling the provider to confirm anything. with a real supabase JWT you can write whatever you want into ext_connections:

```bash
  curl -X POST http://localhost:8000/api/auth/complete-oauth \
    -H "Authorization: Bearer $JWT" \
    -H 'Content-Type: application/json' \
    -d '{"user_id":"...","email":"attacker@coreoss-pentest.io","provider":"google","provider_user_id":"GOOGLE-ID-OF-DIFFERENT-PERSON-1234567890","access_token":"ya29.NOT-A-REAL-TOKEN"}'
```

returns 200 and the row lands with `provider_user_id = GOOGLE-ID-OF-DIFFERENT-PERSON-1234567890` and a fabricated token encrypted at rest. now whenever access_token is supplied we call `get_user_info(access_token, provider)` and overwrite those fields with whatever the provider returns, and bail if the email tied to the token doesn't match the authenticated user.

Last one is the avatar download. `_download_avatar_to_r2` did `httpx.get(avatar_url, follow_redirects=True)` against any url the client wanted, no host check, no IP filter. i ran a tiny python http.server on 127.0.0.1:9999 that logs hits, set `avatar_url=http://127.0.0.1:9999/aws-metadata-iam/security-credentials/admin-role` in the complete-oauth body, and the trap logged:

```
  HIT path=/aws-metadata-iam/security-credentials/admin-role ua=python-httpx/0.27.2
```

so an authenticated user could probe internal services or hit cloud metadata. fix is the obvious one: https only, allowlist `*.googleusercontent.com` and `graph.microsoft.com`, resolve the host with
  `socket.getaddrinfo` and reject anything private/loopback/link-local/reserved/multicast, and turn redirect following off so a 302 to 169.254.169.254 can't slip in. after these changes every one of those exploits comes back 200 with a log warning (pub/sub paths, by design so we don't trigger retry storms) or 400 (oauth and validation token), nothing hits the database, and the trap server stays empty. added tests under `tests/unit/` for the avatar guard, microsoft clientState compare, and the pub/sub verifier, with some tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Pub/Sub push authentication for Gmail and Google Calendar webhooks.
  * Enhanced webhook validation for Microsoft Graph endpoints.

* **Bug Fixes**
  * Hardened avatar download security with URL validation and IP checks.
  * Improved OAuth identity verification to enforce email matching.
  * Enhanced webhook notification validation with constant-time comparison.
  * Removed debug logging that exposed sensitive token data.

* **Tests**
  * Added comprehensive unit tests for webhook authentication and avatar URL validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->